### PR TITLE
Add llama-index kdbai base rag notebook

### DIFF
--- a/task-4-model-building/experimental_notebooks/RegulatoryRAG_TRI_Circulars_markdownParser_basic_RAG_kdbai.ipynb
+++ b/task-4-model-building/experimental_notebooks/RegulatoryRAG_TRI_Circulars_markdownParser_basic_RAG_kdbai.ipynb
@@ -1,0 +1,2333 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "collapsed_sections": [
+        "4hyanJvqZzlP",
+        "CJ0qj3DVZ50B",
+        "O5g7hyyoW7Jj",
+        "cMStjLBIZLlk",
+        "qmKd2jtFYmOY",
+        "8jdCECWjaVKs",
+        "9nAb_08SZpi2",
+        "NBTq4MmXeRHD",
+        "QZtApnqOeV-H",
+        "LXRnsF_0mKPt",
+        "qK3sRaOAhapF",
+        "GiIr17wJgu-Z"
+      ]
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "widgets": {
+      "application/vnd.jupyter.widget-state+json": {
+        "1206539f66f1449d810d9cad2aabb6e7": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_0bc6385d4cfd44e0a3cedf095ba94947",
+              "IPY_MODEL_618b0cf1761b4ade9c6db22db431a14d",
+              "IPY_MODEL_1d2acbfaee294bf0ae117c237a5e4279"
+            ],
+            "layout": "IPY_MODEL_16359763e9f0423db14b17f7b9a62347"
+          }
+        },
+        "0bc6385d4cfd44e0a3cedf095ba94947": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_c2641a3eb6454554a0f0298ccf690e9a",
+            "placeholder": "​",
+            "style": "IPY_MODEL_1b5c6600c4b3492dbfe4abe6be520c8c",
+            "value": "100%"
+          }
+        },
+        "618b0cf1761b4ade9c6db22db431a14d": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_e4f48917db9b41518cbad1398f9d38c2",
+            "max": 50,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_6ba4c39952ff45a895742560c8c6718d",
+            "value": 50
+          }
+        },
+        "1d2acbfaee294bf0ae117c237a5e4279": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_47a64e0c956e4512ae347ae14c0d4213",
+            "placeholder": "​",
+            "style": "IPY_MODEL_b826e662dbcd4de8a8f89a9fa36cdfa3",
+            "value": " 50/50 [00:00&lt;00:00, 1235.09it/s]"
+          }
+        },
+        "16359763e9f0423db14b17f7b9a62347": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "c2641a3eb6454554a0f0298ccf690e9a": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "1b5c6600c4b3492dbfe4abe6be520c8c": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "e4f48917db9b41518cbad1398f9d38c2": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "6ba4c39952ff45a895742560c8c6718d": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "47a64e0c956e4512ae347ae14c0d4213": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "b826e662dbcd4de8a8f89a9fa36cdfa3": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        }
+      }
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Libraries"
+      ],
+      "metadata": {
+        "id": "4hyanJvqZzlP"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 19,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "81FquzcWSdlQ",
+        "outputId": "0d5a5c81-8c88-4122-9ac5-034196f7292b"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Requirement already satisfied: llama-index in /usr/local/lib/python3.10/dist-packages (0.12.4)\n",
+            "Requirement already satisfied: llama-index-agent-openai<0.5.0,>=0.4.0 in /usr/local/lib/python3.10/dist-packages (from llama-index) (0.4.0)\n",
+            "Requirement already satisfied: llama-index-cli<0.5.0,>=0.4.0 in /usr/local/lib/python3.10/dist-packages (from llama-index) (0.4.0)\n",
+            "Requirement already satisfied: llama-index-core<0.13.0,>=0.12.4 in /usr/local/lib/python3.10/dist-packages (from llama-index) (0.12.4)\n",
+            "Requirement already satisfied: llama-index-embeddings-openai<0.4.0,>=0.3.0 in /usr/local/lib/python3.10/dist-packages (from llama-index) (0.3.1)\n",
+            "Requirement already satisfied: llama-index-indices-managed-llama-cloud>=0.4.0 in /usr/local/lib/python3.10/dist-packages (from llama-index) (0.6.3)\n",
+            "Requirement already satisfied: llama-index-legacy<0.10.0,>=0.9.48 in /usr/local/lib/python3.10/dist-packages (from llama-index) (0.9.48.post4)\n",
+            "Requirement already satisfied: llama-index-llms-openai<0.4.0,>=0.3.0 in /usr/local/lib/python3.10/dist-packages (from llama-index) (0.3.3)\n",
+            "Requirement already satisfied: llama-index-multi-modal-llms-openai<0.4.0,>=0.3.0 in /usr/local/lib/python3.10/dist-packages (from llama-index) (0.3.0)\n",
+            "Requirement already satisfied: llama-index-program-openai<0.4.0,>=0.3.0 in /usr/local/lib/python3.10/dist-packages (from llama-index) (0.3.1)\n",
+            "Requirement already satisfied: llama-index-question-gen-openai<0.4.0,>=0.3.0 in /usr/local/lib/python3.10/dist-packages (from llama-index) (0.3.0)\n",
+            "Requirement already satisfied: llama-index-readers-file<0.5.0,>=0.4.0 in /usr/local/lib/python3.10/dist-packages (from llama-index) (0.4.1)\n",
+            "Requirement already satisfied: llama-index-readers-llama-parse>=0.4.0 in /usr/local/lib/python3.10/dist-packages (from llama-index) (0.4.0)\n",
+            "Requirement already satisfied: nltk>3.8.1 in /usr/local/lib/python3.10/dist-packages (from llama-index) (3.9.1)\n",
+            "Requirement already satisfied: openai>=1.14.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-agent-openai<0.5.0,>=0.4.0->llama-index) (1.54.5)\n",
+            "Requirement already satisfied: PyYAML>=6.0.1 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.4->llama-index) (6.0.2)\n",
+            "Requirement already satisfied: SQLAlchemy>=1.4.49 in /usr/local/lib/python3.10/dist-packages (from SQLAlchemy[asyncio]>=1.4.49->llama-index-core<0.13.0,>=0.12.4->llama-index) (2.0.36)\n",
+            "Requirement already satisfied: aiohttp<4.0.0,>=3.8.6 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.4->llama-index) (3.11.9)\n",
+            "Requirement already satisfied: dataclasses-json in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.4->llama-index) (0.6.7)\n",
+            "Requirement already satisfied: deprecated>=1.2.9.3 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.4->llama-index) (1.2.15)\n",
+            "Requirement already satisfied: dirtyjson<2.0.0,>=1.0.8 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.4->llama-index) (1.0.8)\n",
+            "Requirement already satisfied: filetype<2.0.0,>=1.2.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.4->llama-index) (1.2.0)\n",
+            "Requirement already satisfied: fsspec>=2023.5.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.4->llama-index) (2024.10.0)\n",
+            "Requirement already satisfied: httpx in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.4->llama-index) (0.28.0)\n",
+            "Requirement already satisfied: nest-asyncio<2.0.0,>=1.5.8 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.4->llama-index) (1.6.0)\n",
+            "Requirement already satisfied: networkx>=3.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.4->llama-index) (3.4.2)\n",
+            "Requirement already satisfied: numpy in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.4->llama-index) (1.26.4)\n",
+            "Requirement already satisfied: pillow>=9.0.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.4->llama-index) (11.0.0)\n",
+            "Requirement already satisfied: pydantic>=2.8.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.4->llama-index) (2.10.3)\n",
+            "Requirement already satisfied: requests>=2.31.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.4->llama-index) (2.32.3)\n",
+            "Requirement already satisfied: tenacity!=8.4.0,<10.0.0,>=8.2.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.4->llama-index) (8.5.0)\n",
+            "Requirement already satisfied: tiktoken>=0.3.3 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.4->llama-index) (0.8.0)\n",
+            "Requirement already satisfied: tqdm<5.0.0,>=4.66.1 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.4->llama-index) (4.66.6)\n",
+            "Requirement already satisfied: typing-extensions>=4.5.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.4->llama-index) (4.12.2)\n",
+            "Requirement already satisfied: typing-inspect>=0.8.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.4->llama-index) (0.9.0)\n",
+            "Requirement already satisfied: wrapt in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.4->llama-index) (1.17.0)\n",
+            "Requirement already satisfied: llama-cloud>=0.1.5 in /usr/local/lib/python3.10/dist-packages (from llama-index-indices-managed-llama-cloud>=0.4.0->llama-index) (0.1.6)\n",
+            "Requirement already satisfied: pandas in /usr/local/lib/python3.10/dist-packages (from llama-index-legacy<0.10.0,>=0.9.48->llama-index) (2.2.2)\n",
+            "Requirement already satisfied: beautifulsoup4<5.0.0,>=4.12.3 in /usr/local/lib/python3.10/dist-packages (from llama-index-readers-file<0.5.0,>=0.4.0->llama-index) (4.12.3)\n",
+            "Requirement already satisfied: pypdf<6.0.0,>=5.1.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-readers-file<0.5.0,>=0.4.0->llama-index) (5.1.0)\n",
+            "Requirement already satisfied: striprtf<0.0.27,>=0.0.26 in /usr/local/lib/python3.10/dist-packages (from llama-index-readers-file<0.5.0,>=0.4.0->llama-index) (0.0.26)\n",
+            "Requirement already satisfied: llama-parse>=0.5.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-readers-llama-parse>=0.4.0->llama-index) (0.5.17)\n",
+            "Requirement already satisfied: click in /usr/local/lib/python3.10/dist-packages (from nltk>3.8.1->llama-index) (8.1.7)\n",
+            "Requirement already satisfied: joblib in /usr/local/lib/python3.10/dist-packages (from nltk>3.8.1->llama-index) (1.4.2)\n",
+            "Requirement already satisfied: regex>=2021.8.3 in /usr/local/lib/python3.10/dist-packages (from nltk>3.8.1->llama-index) (2024.9.11)\n",
+            "Requirement already satisfied: aiohappyeyeballs>=2.3.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0.0,>=3.8.6->llama-index-core<0.13.0,>=0.12.4->llama-index) (2.4.4)\n",
+            "Requirement already satisfied: aiosignal>=1.1.2 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0.0,>=3.8.6->llama-index-core<0.13.0,>=0.12.4->llama-index) (1.3.1)\n",
+            "Requirement already satisfied: async-timeout<6.0,>=4.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0.0,>=3.8.6->llama-index-core<0.13.0,>=0.12.4->llama-index) (4.0.3)\n",
+            "Requirement already satisfied: attrs>=17.3.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0.0,>=3.8.6->llama-index-core<0.13.0,>=0.12.4->llama-index) (24.2.0)\n",
+            "Requirement already satisfied: frozenlist>=1.1.1 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0.0,>=3.8.6->llama-index-core<0.13.0,>=0.12.4->llama-index) (1.5.0)\n",
+            "Requirement already satisfied: multidict<7.0,>=4.5 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0.0,>=3.8.6->llama-index-core<0.13.0,>=0.12.4->llama-index) (6.1.0)\n",
+            "Requirement already satisfied: propcache>=0.2.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0.0,>=3.8.6->llama-index-core<0.13.0,>=0.12.4->llama-index) (0.2.1)\n",
+            "Requirement already satisfied: yarl<2.0,>=1.17.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0.0,>=3.8.6->llama-index-core<0.13.0,>=0.12.4->llama-index) (1.18.3)\n",
+            "Requirement already satisfied: soupsieve>1.2 in /usr/local/lib/python3.10/dist-packages (from beautifulsoup4<5.0.0,>=4.12.3->llama-index-readers-file<0.5.0,>=0.4.0->llama-index) (2.6)\n",
+            "Requirement already satisfied: anyio in /usr/local/lib/python3.10/dist-packages (from httpx->llama-index-core<0.13.0,>=0.12.4->llama-index) (3.7.1)\n",
+            "Requirement already satisfied: certifi in /usr/local/lib/python3.10/dist-packages (from httpx->llama-index-core<0.13.0,>=0.12.4->llama-index) (2024.8.30)\n",
+            "Requirement already satisfied: httpcore==1.* in /usr/local/lib/python3.10/dist-packages (from httpx->llama-index-core<0.13.0,>=0.12.4->llama-index) (1.0.7)\n",
+            "Requirement already satisfied: idna in /usr/local/lib/python3.10/dist-packages (from httpx->llama-index-core<0.13.0,>=0.12.4->llama-index) (3.10)\n",
+            "Requirement already satisfied: h11<0.15,>=0.13 in /usr/local/lib/python3.10/dist-packages (from httpcore==1.*->httpx->llama-index-core<0.13.0,>=0.12.4->llama-index) (0.14.0)\n",
+            "Requirement already satisfied: distro<2,>=1.7.0 in /usr/local/lib/python3.10/dist-packages (from openai>=1.14.0->llama-index-agent-openai<0.5.0,>=0.4.0->llama-index) (1.9.0)\n",
+            "Requirement already satisfied: jiter<1,>=0.4.0 in /usr/local/lib/python3.10/dist-packages (from openai>=1.14.0->llama-index-agent-openai<0.5.0,>=0.4.0->llama-index) (0.8.0)\n",
+            "Requirement already satisfied: sniffio in /usr/local/lib/python3.10/dist-packages (from openai>=1.14.0->llama-index-agent-openai<0.5.0,>=0.4.0->llama-index) (1.3.1)\n",
+            "Requirement already satisfied: annotated-types>=0.6.0 in /usr/local/lib/python3.10/dist-packages (from pydantic>=2.8.0->llama-index-core<0.13.0,>=0.12.4->llama-index) (0.7.0)\n",
+            "Requirement already satisfied: pydantic-core==2.27.1 in /usr/local/lib/python3.10/dist-packages (from pydantic>=2.8.0->llama-index-core<0.13.0,>=0.12.4->llama-index) (2.27.1)\n",
+            "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.10/dist-packages (from requests>=2.31.0->llama-index-core<0.13.0,>=0.12.4->llama-index) (3.4.0)\n",
+            "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.10/dist-packages (from requests>=2.31.0->llama-index-core<0.13.0,>=0.12.4->llama-index) (2.2.3)\n",
+            "Requirement already satisfied: greenlet!=0.4.17 in /usr/local/lib/python3.10/dist-packages (from SQLAlchemy>=1.4.49->SQLAlchemy[asyncio]>=1.4.49->llama-index-core<0.13.0,>=0.12.4->llama-index) (3.1.1)\n",
+            "Requirement already satisfied: mypy-extensions>=0.3.0 in /usr/local/lib/python3.10/dist-packages (from typing-inspect>=0.8.0->llama-index-core<0.13.0,>=0.12.4->llama-index) (1.0.0)\n",
+            "Requirement already satisfied: marshmallow<4.0.0,>=3.18.0 in /usr/local/lib/python3.10/dist-packages (from dataclasses-json->llama-index-core<0.13.0,>=0.12.4->llama-index) (3.23.1)\n",
+            "Requirement already satisfied: python-dateutil>=2.8.2 in /usr/local/lib/python3.10/dist-packages (from pandas->llama-index-legacy<0.10.0,>=0.9.48->llama-index) (2.8.2)\n",
+            "Requirement already satisfied: pytz>=2020.1 in /usr/local/lib/python3.10/dist-packages (from pandas->llama-index-legacy<0.10.0,>=0.9.48->llama-index) (2024.2)\n",
+            "Requirement already satisfied: tzdata>=2022.7 in /usr/local/lib/python3.10/dist-packages (from pandas->llama-index-legacy<0.10.0,>=0.9.48->llama-index) (2024.2)\n",
+            "Requirement already satisfied: exceptiongroup in /usr/local/lib/python3.10/dist-packages (from anyio->httpx->llama-index-core<0.13.0,>=0.12.4->llama-index) (1.2.2)\n",
+            "Requirement already satisfied: packaging>=17.0 in /usr/local/lib/python3.10/dist-packages (from marshmallow<4.0.0,>=3.18.0->dataclasses-json->llama-index-core<0.13.0,>=0.12.4->llama-index) (24.2)\n",
+            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.10/dist-packages (from python-dateutil>=2.8.2->pandas->llama-index-legacy<0.10.0,>=0.9.48->llama-index) (1.16.0)\n",
+            "Requirement already satisfied: transformers in /usr/local/lib/python3.10/dist-packages (4.46.3)\n",
+            "Requirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from transformers) (3.16.1)\n",
+            "Requirement already satisfied: huggingface-hub<1.0,>=0.23.2 in /usr/local/lib/python3.10/dist-packages (from transformers) (0.26.3)\n",
+            "Requirement already satisfied: numpy>=1.17 in /usr/local/lib/python3.10/dist-packages (from transformers) (1.26.4)\n",
+            "Requirement already satisfied: packaging>=20.0 in /usr/local/lib/python3.10/dist-packages (from transformers) (24.2)\n",
+            "Requirement already satisfied: pyyaml>=5.1 in /usr/local/lib/python3.10/dist-packages (from transformers) (6.0.2)\n",
+            "Requirement already satisfied: regex!=2019.12.17 in /usr/local/lib/python3.10/dist-packages (from transformers) (2024.9.11)\n",
+            "Requirement already satisfied: requests in /usr/local/lib/python3.10/dist-packages (from transformers) (2.32.3)\n",
+            "Requirement already satisfied: tokenizers<0.21,>=0.20 in /usr/local/lib/python3.10/dist-packages (from transformers) (0.20.3)\n",
+            "Requirement already satisfied: safetensors>=0.4.1 in /usr/local/lib/python3.10/dist-packages (from transformers) (0.4.5)\n",
+            "Requirement already satisfied: tqdm>=4.27 in /usr/local/lib/python3.10/dist-packages (from transformers) (4.66.6)\n",
+            "Requirement already satisfied: fsspec>=2023.5.0 in /usr/local/lib/python3.10/dist-packages (from huggingface-hub<1.0,>=0.23.2->transformers) (2024.10.0)\n",
+            "Requirement already satisfied: typing-extensions>=3.7.4.3 in /usr/local/lib/python3.10/dist-packages (from huggingface-hub<1.0,>=0.23.2->transformers) (4.12.2)\n",
+            "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.10/dist-packages (from requests->transformers) (3.4.0)\n",
+            "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.10/dist-packages (from requests->transformers) (3.10)\n",
+            "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.10/dist-packages (from requests->transformers) (2.2.3)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.10/dist-packages (from requests->transformers) (2024.8.30)\n",
+            "Requirement already satisfied: torch in /usr/local/lib/python3.10/dist-packages (2.5.1+cu121)\n",
+            "Requirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from torch) (3.16.1)\n",
+            "Requirement already satisfied: typing-extensions>=4.8.0 in /usr/local/lib/python3.10/dist-packages (from torch) (4.12.2)\n",
+            "Requirement already satisfied: networkx in /usr/local/lib/python3.10/dist-packages (from torch) (3.4.2)\n",
+            "Requirement already satisfied: jinja2 in /usr/local/lib/python3.10/dist-packages (from torch) (3.1.4)\n",
+            "Requirement already satisfied: fsspec in /usr/local/lib/python3.10/dist-packages (from torch) (2024.10.0)\n",
+            "Requirement already satisfied: sympy==1.13.1 in /usr/local/lib/python3.10/dist-packages (from torch) (1.13.1)\n",
+            "Requirement already satisfied: mpmath<1.4,>=1.1.0 in /usr/local/lib/python3.10/dist-packages (from sympy==1.13.1->torch) (1.3.0)\n",
+            "Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.10/dist-packages (from jinja2->torch) (3.0.2)\n",
+            "Requirement already satisfied: llama-index-llms-groq in /usr/local/lib/python3.10/dist-packages (0.3.0)\n",
+            "Requirement already satisfied: llama-index-core<0.13.0,>=0.12.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-llms-groq) (0.12.4)\n",
+            "Requirement already satisfied: llama-index-llms-openai-like<0.4.0,>=0.3.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-llms-groq) (0.3.0)\n",
+            "Requirement already satisfied: PyYAML>=6.0.1 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (6.0.2)\n",
+            "Requirement already satisfied: SQLAlchemy>=1.4.49 in /usr/local/lib/python3.10/dist-packages (from SQLAlchemy[asyncio]>=1.4.49->llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (2.0.36)\n",
+            "Requirement already satisfied: aiohttp<4.0.0,>=3.8.6 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (3.11.9)\n",
+            "Requirement already satisfied: dataclasses-json in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (0.6.7)\n",
+            "Requirement already satisfied: deprecated>=1.2.9.3 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (1.2.15)\n",
+            "Requirement already satisfied: dirtyjson<2.0.0,>=1.0.8 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (1.0.8)\n",
+            "Requirement already satisfied: filetype<2.0.0,>=1.2.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (1.2.0)\n",
+            "Requirement already satisfied: fsspec>=2023.5.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (2024.10.0)\n",
+            "Requirement already satisfied: httpx in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (0.28.0)\n",
+            "Requirement already satisfied: nest-asyncio<2.0.0,>=1.5.8 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (1.6.0)\n",
+            "Requirement already satisfied: networkx>=3.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (3.4.2)\n",
+            "Requirement already satisfied: nltk>3.8.1 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (3.9.1)\n",
+            "Requirement already satisfied: numpy in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (1.26.4)\n",
+            "Requirement already satisfied: pillow>=9.0.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (11.0.0)\n",
+            "Requirement already satisfied: pydantic>=2.8.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (2.10.3)\n",
+            "Requirement already satisfied: requests>=2.31.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (2.32.3)\n",
+            "Requirement already satisfied: tenacity!=8.4.0,<10.0.0,>=8.2.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (8.5.0)\n",
+            "Requirement already satisfied: tiktoken>=0.3.3 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (0.8.0)\n",
+            "Requirement already satisfied: tqdm<5.0.0,>=4.66.1 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (4.66.6)\n",
+            "Requirement already satisfied: typing-extensions>=4.5.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (4.12.2)\n",
+            "Requirement already satisfied: typing-inspect>=0.8.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (0.9.0)\n",
+            "Requirement already satisfied: wrapt in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (1.17.0)\n",
+            "Requirement already satisfied: llama-index-llms-openai<0.4.0,>=0.3.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-llms-openai-like<0.4.0,>=0.3.0->llama-index-llms-groq) (0.3.3)\n",
+            "Requirement already satisfied: transformers<5.0.0,>=4.37.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-llms-openai-like<0.4.0,>=0.3.0->llama-index-llms-groq) (4.46.3)\n",
+            "Requirement already satisfied: aiohappyeyeballs>=2.3.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0.0,>=3.8.6->llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (2.4.4)\n",
+            "Requirement already satisfied: aiosignal>=1.1.2 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0.0,>=3.8.6->llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (1.3.1)\n",
+            "Requirement already satisfied: async-timeout<6.0,>=4.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0.0,>=3.8.6->llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (4.0.3)\n",
+            "Requirement already satisfied: attrs>=17.3.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0.0,>=3.8.6->llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (24.2.0)\n",
+            "Requirement already satisfied: frozenlist>=1.1.1 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0.0,>=3.8.6->llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (1.5.0)\n",
+            "Requirement already satisfied: multidict<7.0,>=4.5 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0.0,>=3.8.6->llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (6.1.0)\n",
+            "Requirement already satisfied: propcache>=0.2.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0.0,>=3.8.6->llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (0.2.1)\n",
+            "Requirement already satisfied: yarl<2.0,>=1.17.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0.0,>=3.8.6->llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (1.18.3)\n",
+            "Requirement already satisfied: openai<2.0.0,>=1.40.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-llms-openai<0.4.0,>=0.3.0->llama-index-llms-openai-like<0.4.0,>=0.3.0->llama-index-llms-groq) (1.54.5)\n",
+            "Requirement already satisfied: click in /usr/local/lib/python3.10/dist-packages (from nltk>3.8.1->llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (8.1.7)\n",
+            "Requirement already satisfied: joblib in /usr/local/lib/python3.10/dist-packages (from nltk>3.8.1->llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (1.4.2)\n",
+            "Requirement already satisfied: regex>=2021.8.3 in /usr/local/lib/python3.10/dist-packages (from nltk>3.8.1->llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (2024.9.11)\n",
+            "Requirement already satisfied: annotated-types>=0.6.0 in /usr/local/lib/python3.10/dist-packages (from pydantic>=2.8.0->llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (0.7.0)\n",
+            "Requirement already satisfied: pydantic-core==2.27.1 in /usr/local/lib/python3.10/dist-packages (from pydantic>=2.8.0->llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (2.27.1)\n",
+            "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.10/dist-packages (from requests>=2.31.0->llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (3.4.0)\n",
+            "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.10/dist-packages (from requests>=2.31.0->llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (3.10)\n",
+            "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.10/dist-packages (from requests>=2.31.0->llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (2.2.3)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.10/dist-packages (from requests>=2.31.0->llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (2024.8.30)\n",
+            "Requirement already satisfied: greenlet!=0.4.17 in /usr/local/lib/python3.10/dist-packages (from SQLAlchemy>=1.4.49->SQLAlchemy[asyncio]>=1.4.49->llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (3.1.1)\n",
+            "Requirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from transformers<5.0.0,>=4.37.0->llama-index-llms-openai-like<0.4.0,>=0.3.0->llama-index-llms-groq) (3.16.1)\n",
+            "Requirement already satisfied: huggingface-hub<1.0,>=0.23.2 in /usr/local/lib/python3.10/dist-packages (from transformers<5.0.0,>=4.37.0->llama-index-llms-openai-like<0.4.0,>=0.3.0->llama-index-llms-groq) (0.26.3)\n",
+            "Requirement already satisfied: packaging>=20.0 in /usr/local/lib/python3.10/dist-packages (from transformers<5.0.0,>=4.37.0->llama-index-llms-openai-like<0.4.0,>=0.3.0->llama-index-llms-groq) (24.2)\n",
+            "Requirement already satisfied: tokenizers<0.21,>=0.20 in /usr/local/lib/python3.10/dist-packages (from transformers<5.0.0,>=4.37.0->llama-index-llms-openai-like<0.4.0,>=0.3.0->llama-index-llms-groq) (0.20.3)\n",
+            "Requirement already satisfied: safetensors>=0.4.1 in /usr/local/lib/python3.10/dist-packages (from transformers<5.0.0,>=4.37.0->llama-index-llms-openai-like<0.4.0,>=0.3.0->llama-index-llms-groq) (0.4.5)\n",
+            "Requirement already satisfied: mypy-extensions>=0.3.0 in /usr/local/lib/python3.10/dist-packages (from typing-inspect>=0.8.0->llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (1.0.0)\n",
+            "Requirement already satisfied: marshmallow<4.0.0,>=3.18.0 in /usr/local/lib/python3.10/dist-packages (from dataclasses-json->llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (3.23.1)\n",
+            "Requirement already satisfied: anyio in /usr/local/lib/python3.10/dist-packages (from httpx->llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (3.7.1)\n",
+            "Requirement already satisfied: httpcore==1.* in /usr/local/lib/python3.10/dist-packages (from httpx->llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (1.0.7)\n",
+            "Requirement already satisfied: h11<0.15,>=0.13 in /usr/local/lib/python3.10/dist-packages (from httpcore==1.*->httpx->llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (0.14.0)\n",
+            "Requirement already satisfied: distro<2,>=1.7.0 in /usr/local/lib/python3.10/dist-packages (from openai<2.0.0,>=1.40.0->llama-index-llms-openai<0.4.0,>=0.3.0->llama-index-llms-openai-like<0.4.0,>=0.3.0->llama-index-llms-groq) (1.9.0)\n",
+            "Requirement already satisfied: jiter<1,>=0.4.0 in /usr/local/lib/python3.10/dist-packages (from openai<2.0.0,>=1.40.0->llama-index-llms-openai<0.4.0,>=0.3.0->llama-index-llms-openai-like<0.4.0,>=0.3.0->llama-index-llms-groq) (0.8.0)\n",
+            "Requirement already satisfied: sniffio in /usr/local/lib/python3.10/dist-packages (from openai<2.0.0,>=1.40.0->llama-index-llms-openai<0.4.0,>=0.3.0->llama-index-llms-openai-like<0.4.0,>=0.3.0->llama-index-llms-groq) (1.3.1)\n",
+            "Requirement already satisfied: exceptiongroup in /usr/local/lib/python3.10/dist-packages (from anyio->httpx->llama-index-core<0.13.0,>=0.12.0->llama-index-llms-groq) (1.2.2)\n",
+            "Requirement already satisfied: sentence-transformers in /usr/local/lib/python3.10/dist-packages (3.2.1)\n",
+            "Requirement already satisfied: transformers<5.0.0,>=4.41.0 in /usr/local/lib/python3.10/dist-packages (from sentence-transformers) (4.46.3)\n",
+            "Requirement already satisfied: tqdm in /usr/local/lib/python3.10/dist-packages (from sentence-transformers) (4.66.6)\n",
+            "Requirement already satisfied: torch>=1.11.0 in /usr/local/lib/python3.10/dist-packages (from sentence-transformers) (2.5.1+cu121)\n",
+            "Requirement already satisfied: scikit-learn in /usr/local/lib/python3.10/dist-packages (from sentence-transformers) (1.5.2)\n",
+            "Requirement already satisfied: scipy in /usr/local/lib/python3.10/dist-packages (from sentence-transformers) (1.13.1)\n",
+            "Requirement already satisfied: huggingface-hub>=0.20.0 in /usr/local/lib/python3.10/dist-packages (from sentence-transformers) (0.26.3)\n",
+            "Requirement already satisfied: Pillow in /usr/local/lib/python3.10/dist-packages (from sentence-transformers) (11.0.0)\n",
+            "Requirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from huggingface-hub>=0.20.0->sentence-transformers) (3.16.1)\n",
+            "Requirement already satisfied: fsspec>=2023.5.0 in /usr/local/lib/python3.10/dist-packages (from huggingface-hub>=0.20.0->sentence-transformers) (2024.10.0)\n",
+            "Requirement already satisfied: packaging>=20.9 in /usr/local/lib/python3.10/dist-packages (from huggingface-hub>=0.20.0->sentence-transformers) (24.2)\n",
+            "Requirement already satisfied: pyyaml>=5.1 in /usr/local/lib/python3.10/dist-packages (from huggingface-hub>=0.20.0->sentence-transformers) (6.0.2)\n",
+            "Requirement already satisfied: requests in /usr/local/lib/python3.10/dist-packages (from huggingface-hub>=0.20.0->sentence-transformers) (2.32.3)\n",
+            "Requirement already satisfied: typing-extensions>=3.7.4.3 in /usr/local/lib/python3.10/dist-packages (from huggingface-hub>=0.20.0->sentence-transformers) (4.12.2)\n",
+            "Requirement already satisfied: networkx in /usr/local/lib/python3.10/dist-packages (from torch>=1.11.0->sentence-transformers) (3.4.2)\n",
+            "Requirement already satisfied: jinja2 in /usr/local/lib/python3.10/dist-packages (from torch>=1.11.0->sentence-transformers) (3.1.4)\n",
+            "Requirement already satisfied: sympy==1.13.1 in /usr/local/lib/python3.10/dist-packages (from torch>=1.11.0->sentence-transformers) (1.13.1)\n",
+            "Requirement already satisfied: mpmath<1.4,>=1.1.0 in /usr/local/lib/python3.10/dist-packages (from sympy==1.13.1->torch>=1.11.0->sentence-transformers) (1.3.0)\n",
+            "Requirement already satisfied: numpy>=1.17 in /usr/local/lib/python3.10/dist-packages (from transformers<5.0.0,>=4.41.0->sentence-transformers) (1.26.4)\n",
+            "Requirement already satisfied: regex!=2019.12.17 in /usr/local/lib/python3.10/dist-packages (from transformers<5.0.0,>=4.41.0->sentence-transformers) (2024.9.11)\n",
+            "Requirement already satisfied: tokenizers<0.21,>=0.20 in /usr/local/lib/python3.10/dist-packages (from transformers<5.0.0,>=4.41.0->sentence-transformers) (0.20.3)\n",
+            "Requirement already satisfied: safetensors>=0.4.1 in /usr/local/lib/python3.10/dist-packages (from transformers<5.0.0,>=4.41.0->sentence-transformers) (0.4.5)\n",
+            "Requirement already satisfied: joblib>=1.2.0 in /usr/local/lib/python3.10/dist-packages (from scikit-learn->sentence-transformers) (1.4.2)\n",
+            "Requirement already satisfied: threadpoolctl>=3.1.0 in /usr/local/lib/python3.10/dist-packages (from scikit-learn->sentence-transformers) (3.5.0)\n",
+            "Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.10/dist-packages (from jinja2->torch>=1.11.0->sentence-transformers) (3.0.2)\n",
+            "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.10/dist-packages (from requests->huggingface-hub>=0.20.0->sentence-transformers) (3.4.0)\n",
+            "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.10/dist-packages (from requests->huggingface-hub>=0.20.0->sentence-transformers) (3.10)\n",
+            "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.10/dist-packages (from requests->huggingface-hub>=0.20.0->sentence-transformers) (2.2.3)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.10/dist-packages (from requests->huggingface-hub>=0.20.0->sentence-transformers) (2024.8.30)\n",
+            "Requirement already satisfied: llama-index-embeddings-huggingface in /usr/local/lib/python3.10/dist-packages (0.4.0)\n",
+            "Requirement already satisfied: huggingface-hub>=0.19.0 in /usr/local/lib/python3.10/dist-packages (from huggingface-hub[inference]>=0.19.0->llama-index-embeddings-huggingface) (0.26.3)\n",
+            "Requirement already satisfied: llama-index-core<0.13.0,>=0.12.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-embeddings-huggingface) (0.12.4)\n",
+            "Requirement already satisfied: sentence-transformers>=2.6.1 in /usr/local/lib/python3.10/dist-packages (from llama-index-embeddings-huggingface) (3.2.1)\n",
+            "Requirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from huggingface-hub>=0.19.0->huggingface-hub[inference]>=0.19.0->llama-index-embeddings-huggingface) (3.16.1)\n",
+            "Requirement already satisfied: fsspec>=2023.5.0 in /usr/local/lib/python3.10/dist-packages (from huggingface-hub>=0.19.0->huggingface-hub[inference]>=0.19.0->llama-index-embeddings-huggingface) (2024.10.0)\n",
+            "Requirement already satisfied: packaging>=20.9 in /usr/local/lib/python3.10/dist-packages (from huggingface-hub>=0.19.0->huggingface-hub[inference]>=0.19.0->llama-index-embeddings-huggingface) (24.2)\n",
+            "Requirement already satisfied: pyyaml>=5.1 in /usr/local/lib/python3.10/dist-packages (from huggingface-hub>=0.19.0->huggingface-hub[inference]>=0.19.0->llama-index-embeddings-huggingface) (6.0.2)\n",
+            "Requirement already satisfied: requests in /usr/local/lib/python3.10/dist-packages (from huggingface-hub>=0.19.0->huggingface-hub[inference]>=0.19.0->llama-index-embeddings-huggingface) (2.32.3)\n",
+            "Requirement already satisfied: tqdm>=4.42.1 in /usr/local/lib/python3.10/dist-packages (from huggingface-hub>=0.19.0->huggingface-hub[inference]>=0.19.0->llama-index-embeddings-huggingface) (4.66.6)\n",
+            "Requirement already satisfied: typing-extensions>=3.7.4.3 in /usr/local/lib/python3.10/dist-packages (from huggingface-hub>=0.19.0->huggingface-hub[inference]>=0.19.0->llama-index-embeddings-huggingface) (4.12.2)\n",
+            "Requirement already satisfied: aiohttp in /usr/local/lib/python3.10/dist-packages (from huggingface-hub[inference]>=0.19.0->llama-index-embeddings-huggingface) (3.11.9)\n",
+            "Requirement already satisfied: SQLAlchemy>=1.4.49 in /usr/local/lib/python3.10/dist-packages (from SQLAlchemy[asyncio]>=1.4.49->llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (2.0.36)\n",
+            "Requirement already satisfied: dataclasses-json in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (0.6.7)\n",
+            "Requirement already satisfied: deprecated>=1.2.9.3 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (1.2.15)\n",
+            "Requirement already satisfied: dirtyjson<2.0.0,>=1.0.8 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (1.0.8)\n",
+            "Requirement already satisfied: filetype<2.0.0,>=1.2.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (1.2.0)\n",
+            "Requirement already satisfied: httpx in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (0.28.0)\n",
+            "Requirement already satisfied: nest-asyncio<2.0.0,>=1.5.8 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (1.6.0)\n",
+            "Requirement already satisfied: networkx>=3.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (3.4.2)\n",
+            "Requirement already satisfied: nltk>3.8.1 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (3.9.1)\n",
+            "Requirement already satisfied: numpy in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (1.26.4)\n",
+            "Requirement already satisfied: pillow>=9.0.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (11.0.0)\n",
+            "Requirement already satisfied: pydantic>=2.8.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (2.10.3)\n",
+            "Requirement already satisfied: tenacity!=8.4.0,<10.0.0,>=8.2.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (8.5.0)\n",
+            "Requirement already satisfied: tiktoken>=0.3.3 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (0.8.0)\n",
+            "Requirement already satisfied: typing-inspect>=0.8.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (0.9.0)\n",
+            "Requirement already satisfied: wrapt in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (1.17.0)\n",
+            "Requirement already satisfied: transformers<5.0.0,>=4.41.0 in /usr/local/lib/python3.10/dist-packages (from sentence-transformers>=2.6.1->llama-index-embeddings-huggingface) (4.46.3)\n",
+            "Requirement already satisfied: torch>=1.11.0 in /usr/local/lib/python3.10/dist-packages (from sentence-transformers>=2.6.1->llama-index-embeddings-huggingface) (2.5.1+cu121)\n",
+            "Requirement already satisfied: scikit-learn in /usr/local/lib/python3.10/dist-packages (from sentence-transformers>=2.6.1->llama-index-embeddings-huggingface) (1.5.2)\n",
+            "Requirement already satisfied: scipy in /usr/local/lib/python3.10/dist-packages (from sentence-transformers>=2.6.1->llama-index-embeddings-huggingface) (1.13.1)\n",
+            "Requirement already satisfied: aiohappyeyeballs>=2.3.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp->huggingface-hub[inference]>=0.19.0->llama-index-embeddings-huggingface) (2.4.4)\n",
+            "Requirement already satisfied: aiosignal>=1.1.2 in /usr/local/lib/python3.10/dist-packages (from aiohttp->huggingface-hub[inference]>=0.19.0->llama-index-embeddings-huggingface) (1.3.1)\n",
+            "Requirement already satisfied: async-timeout<6.0,>=4.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp->huggingface-hub[inference]>=0.19.0->llama-index-embeddings-huggingface) (4.0.3)\n",
+            "Requirement already satisfied: attrs>=17.3.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp->huggingface-hub[inference]>=0.19.0->llama-index-embeddings-huggingface) (24.2.0)\n",
+            "Requirement already satisfied: frozenlist>=1.1.1 in /usr/local/lib/python3.10/dist-packages (from aiohttp->huggingface-hub[inference]>=0.19.0->llama-index-embeddings-huggingface) (1.5.0)\n",
+            "Requirement already satisfied: multidict<7.0,>=4.5 in /usr/local/lib/python3.10/dist-packages (from aiohttp->huggingface-hub[inference]>=0.19.0->llama-index-embeddings-huggingface) (6.1.0)\n",
+            "Requirement already satisfied: propcache>=0.2.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp->huggingface-hub[inference]>=0.19.0->llama-index-embeddings-huggingface) (0.2.1)\n",
+            "Requirement already satisfied: yarl<2.0,>=1.17.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp->huggingface-hub[inference]>=0.19.0->llama-index-embeddings-huggingface) (1.18.3)\n",
+            "Requirement already satisfied: click in /usr/local/lib/python3.10/dist-packages (from nltk>3.8.1->llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (8.1.7)\n",
+            "Requirement already satisfied: joblib in /usr/local/lib/python3.10/dist-packages (from nltk>3.8.1->llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (1.4.2)\n",
+            "Requirement already satisfied: regex>=2021.8.3 in /usr/local/lib/python3.10/dist-packages (from nltk>3.8.1->llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (2024.9.11)\n",
+            "Requirement already satisfied: annotated-types>=0.6.0 in /usr/local/lib/python3.10/dist-packages (from pydantic>=2.8.0->llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (0.7.0)\n",
+            "Requirement already satisfied: pydantic-core==2.27.1 in /usr/local/lib/python3.10/dist-packages (from pydantic>=2.8.0->llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (2.27.1)\n",
+            "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.10/dist-packages (from requests->huggingface-hub>=0.19.0->huggingface-hub[inference]>=0.19.0->llama-index-embeddings-huggingface) (3.4.0)\n",
+            "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.10/dist-packages (from requests->huggingface-hub>=0.19.0->huggingface-hub[inference]>=0.19.0->llama-index-embeddings-huggingface) (3.10)\n",
+            "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.10/dist-packages (from requests->huggingface-hub>=0.19.0->huggingface-hub[inference]>=0.19.0->llama-index-embeddings-huggingface) (2.2.3)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.10/dist-packages (from requests->huggingface-hub>=0.19.0->huggingface-hub[inference]>=0.19.0->llama-index-embeddings-huggingface) (2024.8.30)\n",
+            "Requirement already satisfied: greenlet!=0.4.17 in /usr/local/lib/python3.10/dist-packages (from SQLAlchemy>=1.4.49->SQLAlchemy[asyncio]>=1.4.49->llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (3.1.1)\n",
+            "Requirement already satisfied: jinja2 in /usr/local/lib/python3.10/dist-packages (from torch>=1.11.0->sentence-transformers>=2.6.1->llama-index-embeddings-huggingface) (3.1.4)\n",
+            "Requirement already satisfied: sympy==1.13.1 in /usr/local/lib/python3.10/dist-packages (from torch>=1.11.0->sentence-transformers>=2.6.1->llama-index-embeddings-huggingface) (1.13.1)\n",
+            "Requirement already satisfied: mpmath<1.4,>=1.1.0 in /usr/local/lib/python3.10/dist-packages (from sympy==1.13.1->torch>=1.11.0->sentence-transformers>=2.6.1->llama-index-embeddings-huggingface) (1.3.0)\n",
+            "Requirement already satisfied: tokenizers<0.21,>=0.20 in /usr/local/lib/python3.10/dist-packages (from transformers<5.0.0,>=4.41.0->sentence-transformers>=2.6.1->llama-index-embeddings-huggingface) (0.20.3)\n",
+            "Requirement already satisfied: safetensors>=0.4.1 in /usr/local/lib/python3.10/dist-packages (from transformers<5.0.0,>=4.41.0->sentence-transformers>=2.6.1->llama-index-embeddings-huggingface) (0.4.5)\n",
+            "Requirement already satisfied: mypy-extensions>=0.3.0 in /usr/local/lib/python3.10/dist-packages (from typing-inspect>=0.8.0->llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (1.0.0)\n",
+            "Requirement already satisfied: marshmallow<4.0.0,>=3.18.0 in /usr/local/lib/python3.10/dist-packages (from dataclasses-json->llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (3.23.1)\n",
+            "Requirement already satisfied: anyio in /usr/local/lib/python3.10/dist-packages (from httpx->llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (3.7.1)\n",
+            "Requirement already satisfied: httpcore==1.* in /usr/local/lib/python3.10/dist-packages (from httpx->llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (1.0.7)\n",
+            "Requirement already satisfied: h11<0.15,>=0.13 in /usr/local/lib/python3.10/dist-packages (from httpcore==1.*->httpx->llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (0.14.0)\n",
+            "Requirement already satisfied: threadpoolctl>=3.1.0 in /usr/local/lib/python3.10/dist-packages (from scikit-learn->sentence-transformers>=2.6.1->llama-index-embeddings-huggingface) (3.5.0)\n",
+            "Requirement already satisfied: sniffio>=1.1 in /usr/local/lib/python3.10/dist-packages (from anyio->httpx->llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (1.3.1)\n",
+            "Requirement already satisfied: exceptiongroup in /usr/local/lib/python3.10/dist-packages (from anyio->httpx->llama-index-core<0.13.0,>=0.12.0->llama-index-embeddings-huggingface) (1.2.2)\n",
+            "Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.10/dist-packages (from jinja2->torch>=1.11.0->sentence-transformers>=2.6.1->llama-index-embeddings-huggingface) (3.0.2)\n",
+            "Requirement already satisfied: kdbai-client in /usr/local/lib/python3.10/dist-packages (1.5.0)\n",
+            "Requirement already satisfied: botocore<2.0.0,>=1.35.42 in /usr/local/lib/python3.10/dist-packages (from kdbai-client) (1.35.76)\n",
+            "Requirement already satisfied: cohere==5.9.4 in /usr/local/lib/python3.10/dist-packages (from kdbai-client) (5.9.4)\n",
+            "Requirement already satisfied: packaging in /usr/local/lib/python3.10/dist-packages (from kdbai-client) (24.2)\n",
+            "Requirement already satisfied: pandas>=1.5.0 in /usr/local/lib/python3.10/dist-packages (from kdbai-client) (2.2.2)\n",
+            "Requirement already satisfied: pykx<3.0.0,>=2.1.1 in /usr/local/lib/python3.10/dist-packages (from kdbai-client) (2.5.5)\n",
+            "Requirement already satisfied: requests==2.32.3 in /usr/local/lib/python3.10/dist-packages (from kdbai-client) (2.32.3)\n",
+            "Requirement already satisfied: voyageai==0.2.3 in /usr/local/lib/python3.10/dist-packages (from kdbai-client) (0.2.3)\n",
+            "Requirement already satisfied: boto3<2.0.0,>=1.34.0 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai-client) (1.35.76)\n",
+            "Requirement already satisfied: fastavro<2.0.0,>=1.9.4 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai-client) (1.9.7)\n",
+            "Requirement already satisfied: httpx>=0.21.2 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai-client) (0.28.0)\n",
+            "Requirement already satisfied: httpx-sse==0.4.0 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai-client) (0.4.0)\n",
+            "Requirement already satisfied: parameterized<0.10.0,>=0.9.0 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai-client) (0.9.0)\n",
+            "Requirement already satisfied: pydantic>=1.9.2 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai-client) (2.10.3)\n",
+            "Requirement already satisfied: pydantic-core<3.0.0,>=2.18.2 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai-client) (2.27.1)\n",
+            "Requirement already satisfied: tokenizers<1,>=0.15 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai-client) (0.20.3)\n",
+            "Requirement already satisfied: types-requests<3.0.0,>=2.0.0 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai-client) (2.32.0.20241016)\n",
+            "Requirement already satisfied: typing_extensions>=4.0.0 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai-client) (4.12.2)\n",
+            "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.10/dist-packages (from requests==2.32.3->kdbai-client) (3.4.0)\n",
+            "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.10/dist-packages (from requests==2.32.3->kdbai-client) (3.10)\n",
+            "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.10/dist-packages (from requests==2.32.3->kdbai-client) (2.2.3)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.10/dist-packages (from requests==2.32.3->kdbai-client) (2024.8.30)\n",
+            "Requirement already satisfied: aiohttp<4.0,>=3.5 in /usr/local/lib/python3.10/dist-packages (from voyageai==0.2.3->kdbai-client) (3.11.9)\n",
+            "Requirement already satisfied: aiolimiter<2.0.0,>=1.1.0 in /usr/local/lib/python3.10/dist-packages (from voyageai==0.2.3->kdbai-client) (1.2.1)\n",
+            "Requirement already satisfied: numpy>=1.11 in /usr/local/lib/python3.10/dist-packages (from voyageai==0.2.3->kdbai-client) (1.26.4)\n",
+            "Requirement already satisfied: tenacity>=8.0.1 in /usr/local/lib/python3.10/dist-packages (from voyageai==0.2.3->kdbai-client) (8.5.0)\n",
+            "Requirement already satisfied: jmespath<2.0.0,>=0.7.1 in /usr/local/lib/python3.10/dist-packages (from botocore<2.0.0,>=1.35.42->kdbai-client) (1.0.1)\n",
+            "Requirement already satisfied: python-dateutil<3.0.0,>=2.1 in /usr/local/lib/python3.10/dist-packages (from botocore<2.0.0,>=1.35.42->kdbai-client) (2.8.2)\n",
+            "Requirement already satisfied: pytz>=2020.1 in /usr/local/lib/python3.10/dist-packages (from pandas>=1.5.0->kdbai-client) (2024.2)\n",
+            "Requirement already satisfied: tzdata>=2022.7 in /usr/local/lib/python3.10/dist-packages (from pandas>=1.5.0->kdbai-client) (2024.2)\n",
+            "Requirement already satisfied: toml~=0.10.2 in /usr/local/lib/python3.10/dist-packages (from pykx<3.0.0,>=2.1.1->kdbai-client) (0.10.2)\n",
+            "Requirement already satisfied: aiohappyeyeballs>=2.3.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0,>=3.5->voyageai==0.2.3->kdbai-client) (2.4.4)\n",
+            "Requirement already satisfied: aiosignal>=1.1.2 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0,>=3.5->voyageai==0.2.3->kdbai-client) (1.3.1)\n",
+            "Requirement already satisfied: async-timeout<6.0,>=4.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0,>=3.5->voyageai==0.2.3->kdbai-client) (4.0.3)\n",
+            "Requirement already satisfied: attrs>=17.3.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0,>=3.5->voyageai==0.2.3->kdbai-client) (24.2.0)\n",
+            "Requirement already satisfied: frozenlist>=1.1.1 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0,>=3.5->voyageai==0.2.3->kdbai-client) (1.5.0)\n",
+            "Requirement already satisfied: multidict<7.0,>=4.5 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0,>=3.5->voyageai==0.2.3->kdbai-client) (6.1.0)\n",
+            "Requirement already satisfied: propcache>=0.2.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0,>=3.5->voyageai==0.2.3->kdbai-client) (0.2.1)\n",
+            "Requirement already satisfied: yarl<2.0,>=1.17.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0,>=3.5->voyageai==0.2.3->kdbai-client) (1.18.3)\n",
+            "Requirement already satisfied: s3transfer<0.11.0,>=0.10.0 in /usr/local/lib/python3.10/dist-packages (from boto3<2.0.0,>=1.34.0->cohere==5.9.4->kdbai-client) (0.10.4)\n",
+            "Requirement already satisfied: anyio in /usr/local/lib/python3.10/dist-packages (from httpx>=0.21.2->cohere==5.9.4->kdbai-client) (3.7.1)\n",
+            "Requirement already satisfied: httpcore==1.* in /usr/local/lib/python3.10/dist-packages (from httpx>=0.21.2->cohere==5.9.4->kdbai-client) (1.0.7)\n",
+            "Requirement already satisfied: h11<0.15,>=0.13 in /usr/local/lib/python3.10/dist-packages (from httpcore==1.*->httpx>=0.21.2->cohere==5.9.4->kdbai-client) (0.14.0)\n",
+            "Requirement already satisfied: annotated-types>=0.6.0 in /usr/local/lib/python3.10/dist-packages (from pydantic>=1.9.2->cohere==5.9.4->kdbai-client) (0.7.0)\n",
+            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.10/dist-packages (from python-dateutil<3.0.0,>=2.1->botocore<2.0.0,>=1.35.42->kdbai-client) (1.16.0)\n",
+            "Requirement already satisfied: huggingface-hub<1.0,>=0.16.4 in /usr/local/lib/python3.10/dist-packages (from tokenizers<1,>=0.15->cohere==5.9.4->kdbai-client) (0.26.3)\n",
+            "Requirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers<1,>=0.15->cohere==5.9.4->kdbai-client) (3.16.1)\n",
+            "Requirement already satisfied: fsspec>=2023.5.0 in /usr/local/lib/python3.10/dist-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers<1,>=0.15->cohere==5.9.4->kdbai-client) (2024.10.0)\n",
+            "Requirement already satisfied: pyyaml>=5.1 in /usr/local/lib/python3.10/dist-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers<1,>=0.15->cohere==5.9.4->kdbai-client) (6.0.2)\n",
+            "Requirement already satisfied: tqdm>=4.42.1 in /usr/local/lib/python3.10/dist-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers<1,>=0.15->cohere==5.9.4->kdbai-client) (4.66.6)\n",
+            "Requirement already satisfied: sniffio>=1.1 in /usr/local/lib/python3.10/dist-packages (from anyio->httpx>=0.21.2->cohere==5.9.4->kdbai-client) (1.3.1)\n",
+            "Requirement already satisfied: exceptiongroup in /usr/local/lib/python3.10/dist-packages (from anyio->httpx>=0.21.2->cohere==5.9.4->kdbai-client) (1.2.2)\n",
+            "Requirement already satisfied: llama-index-vector-stores-kdbai in /usr/local/lib/python3.10/dist-packages (0.5.0)\n",
+            "Requirement already satisfied: kdbai-client>=1.4.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-vector-stores-kdbai) (1.5.0)\n",
+            "Requirement already satisfied: llama-index-core<0.13.0,>=0.12.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-vector-stores-kdbai) (0.12.4)\n",
+            "Requirement already satisfied: pandas in /usr/local/lib/python3.10/dist-packages (from llama-index-vector-stores-kdbai) (2.2.2)\n",
+            "Requirement already satisfied: pykx<3.0.0,>=2.1.1 in /usr/local/lib/python3.10/dist-packages (from llama-index-vector-stores-kdbai) (2.5.5)\n",
+            "Requirement already satisfied: botocore<2.0.0,>=1.35.42 in /usr/local/lib/python3.10/dist-packages (from kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (1.35.76)\n",
+            "Requirement already satisfied: cohere==5.9.4 in /usr/local/lib/python3.10/dist-packages (from kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (5.9.4)\n",
+            "Requirement already satisfied: packaging in /usr/local/lib/python3.10/dist-packages (from kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (24.2)\n",
+            "Requirement already satisfied: requests==2.32.3 in /usr/local/lib/python3.10/dist-packages (from kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (2.32.3)\n",
+            "Requirement already satisfied: voyageai==0.2.3 in /usr/local/lib/python3.10/dist-packages (from kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (0.2.3)\n",
+            "Requirement already satisfied: boto3<2.0.0,>=1.34.0 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (1.35.76)\n",
+            "Requirement already satisfied: fastavro<2.0.0,>=1.9.4 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (1.9.7)\n",
+            "Requirement already satisfied: httpx>=0.21.2 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (0.28.0)\n",
+            "Requirement already satisfied: httpx-sse==0.4.0 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (0.4.0)\n",
+            "Requirement already satisfied: parameterized<0.10.0,>=0.9.0 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (0.9.0)\n",
+            "Requirement already satisfied: pydantic>=1.9.2 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (2.10.3)\n",
+            "Requirement already satisfied: pydantic-core<3.0.0,>=2.18.2 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (2.27.1)\n",
+            "Requirement already satisfied: tokenizers<1,>=0.15 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (0.20.3)\n",
+            "Requirement already satisfied: types-requests<3.0.0,>=2.0.0 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (2.32.0.20241016)\n",
+            "Requirement already satisfied: typing_extensions>=4.0.0 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (4.12.2)\n",
+            "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.10/dist-packages (from requests==2.32.3->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (3.4.0)\n",
+            "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.10/dist-packages (from requests==2.32.3->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (3.10)\n",
+            "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.10/dist-packages (from requests==2.32.3->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (2.2.3)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.10/dist-packages (from requests==2.32.3->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (2024.8.30)\n",
+            "Requirement already satisfied: aiohttp<4.0,>=3.5 in /usr/local/lib/python3.10/dist-packages (from voyageai==0.2.3->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (3.11.9)\n",
+            "Requirement already satisfied: aiolimiter<2.0.0,>=1.1.0 in /usr/local/lib/python3.10/dist-packages (from voyageai==0.2.3->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (1.2.1)\n",
+            "Requirement already satisfied: numpy>=1.11 in /usr/local/lib/python3.10/dist-packages (from voyageai==0.2.3->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (1.26.4)\n",
+            "Requirement already satisfied: tenacity>=8.0.1 in /usr/local/lib/python3.10/dist-packages (from voyageai==0.2.3->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (8.5.0)\n",
+            "Requirement already satisfied: PyYAML>=6.0.1 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-vector-stores-kdbai) (6.0.2)\n",
+            "Requirement already satisfied: SQLAlchemy>=1.4.49 in /usr/local/lib/python3.10/dist-packages (from SQLAlchemy[asyncio]>=1.4.49->llama-index-core<0.13.0,>=0.12.0->llama-index-vector-stores-kdbai) (2.0.36)\n",
+            "Requirement already satisfied: dataclasses-json in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-vector-stores-kdbai) (0.6.7)\n",
+            "Requirement already satisfied: deprecated>=1.2.9.3 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-vector-stores-kdbai) (1.2.15)\n",
+            "Requirement already satisfied: dirtyjson<2.0.0,>=1.0.8 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-vector-stores-kdbai) (1.0.8)\n",
+            "Requirement already satisfied: filetype<2.0.0,>=1.2.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-vector-stores-kdbai) (1.2.0)\n",
+            "Requirement already satisfied: fsspec>=2023.5.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-vector-stores-kdbai) (2024.10.0)\n",
+            "Requirement already satisfied: nest-asyncio<2.0.0,>=1.5.8 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-vector-stores-kdbai) (1.6.0)\n",
+            "Requirement already satisfied: networkx>=3.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-vector-stores-kdbai) (3.4.2)\n",
+            "Requirement already satisfied: nltk>3.8.1 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-vector-stores-kdbai) (3.9.1)\n",
+            "Requirement already satisfied: pillow>=9.0.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-vector-stores-kdbai) (11.0.0)\n",
+            "Requirement already satisfied: tiktoken>=0.3.3 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-vector-stores-kdbai) (0.8.0)\n",
+            "Requirement already satisfied: tqdm<5.0.0,>=4.66.1 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-vector-stores-kdbai) (4.66.6)\n",
+            "Requirement already satisfied: typing-inspect>=0.8.0 in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-vector-stores-kdbai) (0.9.0)\n",
+            "Requirement already satisfied: wrapt in /usr/local/lib/python3.10/dist-packages (from llama-index-core<0.13.0,>=0.12.0->llama-index-vector-stores-kdbai) (1.17.0)\n",
+            "Requirement already satisfied: python-dateutil>=2.8.2 in /usr/local/lib/python3.10/dist-packages (from pandas->llama-index-vector-stores-kdbai) (2.8.2)\n",
+            "Requirement already satisfied: pytz>=2020.1 in /usr/local/lib/python3.10/dist-packages (from pandas->llama-index-vector-stores-kdbai) (2024.2)\n",
+            "Requirement already satisfied: tzdata>=2022.7 in /usr/local/lib/python3.10/dist-packages (from pandas->llama-index-vector-stores-kdbai) (2024.2)\n",
+            "Requirement already satisfied: toml~=0.10.2 in /usr/local/lib/python3.10/dist-packages (from pykx<3.0.0,>=2.1.1->llama-index-vector-stores-kdbai) (0.10.2)\n",
+            "Requirement already satisfied: aiohappyeyeballs>=2.3.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0,>=3.5->voyageai==0.2.3->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (2.4.4)\n",
+            "Requirement already satisfied: aiosignal>=1.1.2 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0,>=3.5->voyageai==0.2.3->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (1.3.1)\n",
+            "Requirement already satisfied: async-timeout<6.0,>=4.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0,>=3.5->voyageai==0.2.3->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (4.0.3)\n",
+            "Requirement already satisfied: attrs>=17.3.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0,>=3.5->voyageai==0.2.3->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (24.2.0)\n",
+            "Requirement already satisfied: frozenlist>=1.1.1 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0,>=3.5->voyageai==0.2.3->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (1.5.0)\n",
+            "Requirement already satisfied: multidict<7.0,>=4.5 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0,>=3.5->voyageai==0.2.3->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (6.1.0)\n",
+            "Requirement already satisfied: propcache>=0.2.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0,>=3.5->voyageai==0.2.3->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (0.2.1)\n",
+            "Requirement already satisfied: yarl<2.0,>=1.17.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0,>=3.5->voyageai==0.2.3->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (1.18.3)\n",
+            "Requirement already satisfied: jmespath<2.0.0,>=0.7.1 in /usr/local/lib/python3.10/dist-packages (from botocore<2.0.0,>=1.35.42->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (1.0.1)\n",
+            "Requirement already satisfied: anyio in /usr/local/lib/python3.10/dist-packages (from httpx>=0.21.2->cohere==5.9.4->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (3.7.1)\n",
+            "Requirement already satisfied: httpcore==1.* in /usr/local/lib/python3.10/dist-packages (from httpx>=0.21.2->cohere==5.9.4->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (1.0.7)\n",
+            "Requirement already satisfied: h11<0.15,>=0.13 in /usr/local/lib/python3.10/dist-packages (from httpcore==1.*->httpx>=0.21.2->cohere==5.9.4->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (0.14.0)\n",
+            "Requirement already satisfied: click in /usr/local/lib/python3.10/dist-packages (from nltk>3.8.1->llama-index-core<0.13.0,>=0.12.0->llama-index-vector-stores-kdbai) (8.1.7)\n",
+            "Requirement already satisfied: joblib in /usr/local/lib/python3.10/dist-packages (from nltk>3.8.1->llama-index-core<0.13.0,>=0.12.0->llama-index-vector-stores-kdbai) (1.4.2)\n",
+            "Requirement already satisfied: regex>=2021.8.3 in /usr/local/lib/python3.10/dist-packages (from nltk>3.8.1->llama-index-core<0.13.0,>=0.12.0->llama-index-vector-stores-kdbai) (2024.9.11)\n",
+            "Requirement already satisfied: annotated-types>=0.6.0 in /usr/local/lib/python3.10/dist-packages (from pydantic>=1.9.2->cohere==5.9.4->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (0.7.0)\n",
+            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.10/dist-packages (from python-dateutil>=2.8.2->pandas->llama-index-vector-stores-kdbai) (1.16.0)\n",
+            "Requirement already satisfied: greenlet!=0.4.17 in /usr/local/lib/python3.10/dist-packages (from SQLAlchemy>=1.4.49->SQLAlchemy[asyncio]>=1.4.49->llama-index-core<0.13.0,>=0.12.0->llama-index-vector-stores-kdbai) (3.1.1)\n",
+            "Requirement already satisfied: mypy-extensions>=0.3.0 in /usr/local/lib/python3.10/dist-packages (from typing-inspect>=0.8.0->llama-index-core<0.13.0,>=0.12.0->llama-index-vector-stores-kdbai) (1.0.0)\n",
+            "Requirement already satisfied: marshmallow<4.0.0,>=3.18.0 in /usr/local/lib/python3.10/dist-packages (from dataclasses-json->llama-index-core<0.13.0,>=0.12.0->llama-index-vector-stores-kdbai) (3.23.1)\n",
+            "Requirement already satisfied: s3transfer<0.11.0,>=0.10.0 in /usr/local/lib/python3.10/dist-packages (from boto3<2.0.0,>=1.34.0->cohere==5.9.4->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (0.10.4)\n",
+            "Requirement already satisfied: huggingface-hub<1.0,>=0.16.4 in /usr/local/lib/python3.10/dist-packages (from tokenizers<1,>=0.15->cohere==5.9.4->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (0.26.3)\n",
+            "Requirement already satisfied: sniffio>=1.1 in /usr/local/lib/python3.10/dist-packages (from anyio->httpx>=0.21.2->cohere==5.9.4->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (1.3.1)\n",
+            "Requirement already satisfied: exceptiongroup in /usr/local/lib/python3.10/dist-packages (from anyio->httpx>=0.21.2->cohere==5.9.4->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (1.2.2)\n",
+            "Requirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers<1,>=0.15->cohere==5.9.4->kdbai-client>=1.4.0->llama-index-vector-stores-kdbai) (3.16.1)\n",
+            "Requirement already satisfied: kdbai_client in /usr/local/lib/python3.10/dist-packages (1.5.0)\n",
+            "Requirement already satisfied: pandas in /usr/local/lib/python3.10/dist-packages (2.2.2)\n",
+            "Requirement already satisfied: botocore<2.0.0,>=1.35.42 in /usr/local/lib/python3.10/dist-packages (from kdbai_client) (1.35.76)\n",
+            "Requirement already satisfied: cohere==5.9.4 in /usr/local/lib/python3.10/dist-packages (from kdbai_client) (5.9.4)\n",
+            "Requirement already satisfied: packaging in /usr/local/lib/python3.10/dist-packages (from kdbai_client) (24.2)\n",
+            "Requirement already satisfied: pykx<3.0.0,>=2.1.1 in /usr/local/lib/python3.10/dist-packages (from kdbai_client) (2.5.5)\n",
+            "Requirement already satisfied: requests==2.32.3 in /usr/local/lib/python3.10/dist-packages (from kdbai_client) (2.32.3)\n",
+            "Requirement already satisfied: voyageai==0.2.3 in /usr/local/lib/python3.10/dist-packages (from kdbai_client) (0.2.3)\n",
+            "Requirement already satisfied: boto3<2.0.0,>=1.34.0 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai_client) (1.35.76)\n",
+            "Requirement already satisfied: fastavro<2.0.0,>=1.9.4 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai_client) (1.9.7)\n",
+            "Requirement already satisfied: httpx>=0.21.2 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai_client) (0.28.0)\n",
+            "Requirement already satisfied: httpx-sse==0.4.0 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai_client) (0.4.0)\n",
+            "Requirement already satisfied: parameterized<0.10.0,>=0.9.0 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai_client) (0.9.0)\n",
+            "Requirement already satisfied: pydantic>=1.9.2 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai_client) (2.10.3)\n",
+            "Requirement already satisfied: pydantic-core<3.0.0,>=2.18.2 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai_client) (2.27.1)\n",
+            "Requirement already satisfied: tokenizers<1,>=0.15 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai_client) (0.20.3)\n",
+            "Requirement already satisfied: types-requests<3.0.0,>=2.0.0 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai_client) (2.32.0.20241016)\n",
+            "Requirement already satisfied: typing_extensions>=4.0.0 in /usr/local/lib/python3.10/dist-packages (from cohere==5.9.4->kdbai_client) (4.12.2)\n",
+            "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.10/dist-packages (from requests==2.32.3->kdbai_client) (3.4.0)\n",
+            "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.10/dist-packages (from requests==2.32.3->kdbai_client) (3.10)\n",
+            "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.10/dist-packages (from requests==2.32.3->kdbai_client) (2.2.3)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.10/dist-packages (from requests==2.32.3->kdbai_client) (2024.8.30)\n",
+            "Requirement already satisfied: aiohttp<4.0,>=3.5 in /usr/local/lib/python3.10/dist-packages (from voyageai==0.2.3->kdbai_client) (3.11.9)\n",
+            "Requirement already satisfied: aiolimiter<2.0.0,>=1.1.0 in /usr/local/lib/python3.10/dist-packages (from voyageai==0.2.3->kdbai_client) (1.2.1)\n",
+            "Requirement already satisfied: numpy>=1.11 in /usr/local/lib/python3.10/dist-packages (from voyageai==0.2.3->kdbai_client) (1.26.4)\n",
+            "Requirement already satisfied: tenacity>=8.0.1 in /usr/local/lib/python3.10/dist-packages (from voyageai==0.2.3->kdbai_client) (8.5.0)\n",
+            "Requirement already satisfied: python-dateutil>=2.8.2 in /usr/local/lib/python3.10/dist-packages (from pandas) (2.8.2)\n",
+            "Requirement already satisfied: pytz>=2020.1 in /usr/local/lib/python3.10/dist-packages (from pandas) (2024.2)\n",
+            "Requirement already satisfied: tzdata>=2022.7 in /usr/local/lib/python3.10/dist-packages (from pandas) (2024.2)\n",
+            "Requirement already satisfied: jmespath<2.0.0,>=0.7.1 in /usr/local/lib/python3.10/dist-packages (from botocore<2.0.0,>=1.35.42->kdbai_client) (1.0.1)\n",
+            "Requirement already satisfied: toml~=0.10.2 in /usr/local/lib/python3.10/dist-packages (from pykx<3.0.0,>=2.1.1->kdbai_client) (0.10.2)\n",
+            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.10/dist-packages (from python-dateutil>=2.8.2->pandas) (1.16.0)\n",
+            "Requirement already satisfied: aiohappyeyeballs>=2.3.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0,>=3.5->voyageai==0.2.3->kdbai_client) (2.4.4)\n",
+            "Requirement already satisfied: aiosignal>=1.1.2 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0,>=3.5->voyageai==0.2.3->kdbai_client) (1.3.1)\n",
+            "Requirement already satisfied: async-timeout<6.0,>=4.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0,>=3.5->voyageai==0.2.3->kdbai_client) (4.0.3)\n",
+            "Requirement already satisfied: attrs>=17.3.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0,>=3.5->voyageai==0.2.3->kdbai_client) (24.2.0)\n",
+            "Requirement already satisfied: frozenlist>=1.1.1 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0,>=3.5->voyageai==0.2.3->kdbai_client) (1.5.0)\n",
+            "Requirement already satisfied: multidict<7.0,>=4.5 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0,>=3.5->voyageai==0.2.3->kdbai_client) (6.1.0)\n",
+            "Requirement already satisfied: propcache>=0.2.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0,>=3.5->voyageai==0.2.3->kdbai_client) (0.2.1)\n",
+            "Requirement already satisfied: yarl<2.0,>=1.17.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp<4.0,>=3.5->voyageai==0.2.3->kdbai_client) (1.18.3)\n",
+            "Requirement already satisfied: s3transfer<0.11.0,>=0.10.0 in /usr/local/lib/python3.10/dist-packages (from boto3<2.0.0,>=1.34.0->cohere==5.9.4->kdbai_client) (0.10.4)\n",
+            "Requirement already satisfied: anyio in /usr/local/lib/python3.10/dist-packages (from httpx>=0.21.2->cohere==5.9.4->kdbai_client) (3.7.1)\n",
+            "Requirement already satisfied: httpcore==1.* in /usr/local/lib/python3.10/dist-packages (from httpx>=0.21.2->cohere==5.9.4->kdbai_client) (1.0.7)\n",
+            "Requirement already satisfied: h11<0.15,>=0.13 in /usr/local/lib/python3.10/dist-packages (from httpcore==1.*->httpx>=0.21.2->cohere==5.9.4->kdbai_client) (0.14.0)\n",
+            "Requirement already satisfied: annotated-types>=0.6.0 in /usr/local/lib/python3.10/dist-packages (from pydantic>=1.9.2->cohere==5.9.4->kdbai_client) (0.7.0)\n",
+            "Requirement already satisfied: huggingface-hub<1.0,>=0.16.4 in /usr/local/lib/python3.10/dist-packages (from tokenizers<1,>=0.15->cohere==5.9.4->kdbai_client) (0.26.3)\n",
+            "Requirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers<1,>=0.15->cohere==5.9.4->kdbai_client) (3.16.1)\n",
+            "Requirement already satisfied: fsspec>=2023.5.0 in /usr/local/lib/python3.10/dist-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers<1,>=0.15->cohere==5.9.4->kdbai_client) (2024.10.0)\n",
+            "Requirement already satisfied: pyyaml>=5.1 in /usr/local/lib/python3.10/dist-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers<1,>=0.15->cohere==5.9.4->kdbai_client) (6.0.2)\n",
+            "Requirement already satisfied: tqdm>=4.42.1 in /usr/local/lib/python3.10/dist-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers<1,>=0.15->cohere==5.9.4->kdbai_client) (4.66.6)\n",
+            "Requirement already satisfied: sniffio>=1.1 in /usr/local/lib/python3.10/dist-packages (from anyio->httpx>=0.21.2->cohere==5.9.4->kdbai_client) (1.3.1)\n",
+            "Requirement already satisfied: exceptiongroup in /usr/local/lib/python3.10/dist-packages (from anyio->httpx>=0.21.2->cohere==5.9.4->kdbai_client) (1.2.2)\n"
+          ]
+        }
+      ],
+      "source": [
+        "%pip install llama-index\n",
+        "%pip install transformers\n",
+        "%pip install torch\n",
+        "%pip install llama-index-llms-groq\n",
+        "%pip install sentence-transformers\n",
+        "%pip install \"llama-index-embeddings-huggingface\"\n",
+        "%pip install kdbai-client\n",
+        "%pip install llama-index-vector-stores-kdbai\n",
+        "%pip install kdbai_client pandas"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import pandas as pd\n",
+        "from typing import List, Dict\n",
+        "from llama_index.core import VectorStoreIndex, ServiceContext, Document\n",
+        "from llama_index.core.node_parser import SentenceSplitter, MarkdownNodeParser\n",
+        "from llama_index.embeddings.huggingface import HuggingFaceEmbedding\n",
+        "from llama_index.llms.groq import Groq\n",
+        "from llama_index.core.llms import ChatMessage\n",
+        "import kdbai_client as kdbai\n",
+        "\n",
+        "import time\n",
+        "from tqdm.notebook import tqdm\n",
+        "import matplotlib.pyplot as plt"
+      ],
+      "metadata": {
+        "id": "hxsO6P24TFnJ"
+      },
+      "execution_count": 20,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Data Loading"
+      ],
+      "metadata": {
+        "id": "CJ0qj3DVZ50B"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def load_data(csv_path: str, text_col: List[str], metadata_cols: List[str]) -> List[Document]:\n",
+        "  \"\"\"\n",
+        "  Load documents and include class in metadata\n",
+        "  \"\"\"\n",
+        "  df = pd.read_csv(csv_path)\n",
+        "  documents = []\n",
+        "  cols = ['document_id', 'class', 'issuing_authority', 'title', 'issue_date', 'reference_number']\n",
+        "  for _, row in df.iterrows():\n",
+        "      text = str(row[text_col])\n",
+        "      doc = Document(\n",
+        "          text=text,\n",
+        "          metadata= {cols[i]: row[col] for i, col in enumerate(metadata_cols)}\n",
+        "      )\n",
+        "      documents.append(doc)\n",
+        "  return documents\n",
+        "\n",
+        "DATA_PATH = \"/content/drive/MyDrive/Omdena/Regulatory RAG (SL Chapter)/code/model dev/data/2024_11_28 v0_LK_tea_dataset.csv\"\n",
+        "text_col = 'markdown_content'\n",
+        "metadata_cols = ['id', 'class', 'issuing_authority', 'llama_title', 'llama_issue_date', 'llama_reference_number']\n",
+        "\n",
+        "all_documents = load_data(DATA_PATH, text_col, metadata_cols)\n",
+        "len(all_documents)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "nVfXRRS5THRw",
+        "outputId": "f24bccbb-3a91-422a-aa1e-66a15627f3b1"
+      },
+      "execution_count": 21,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "167"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 21
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "circulars_docs = [doc for doc in all_documents if doc.metadata['class'] == 'circular']\n",
+        "len(circulars_docs)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "59OHDF3TVbOk",
+        "outputId": "a4e117ef-6e79-4d13-fee1-3c1b75f38d99"
+      },
+      "execution_count": 22,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "107"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 22
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "set([doc.metadata['issuing_authority'] for doc in circulars_docs])"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "lMNGdmxbWUmb",
+        "outputId": "e6445a6a-1d8a-4492-ba82-59fb6500c406"
+      },
+      "execution_count": 23,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "{'Tea Board', 'Tea Board Analytical Lab', 'Tea Research Institute'}"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 23
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "tri_circulars_docs = [doc for doc in all_documents if ((doc.metadata['class'] == 'circular') and (doc.metadata['issuing_authority'] == ('Tea Research Institute')))]\n",
+        "len(tri_circulars_docs)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "5od8bFWjVa4B",
+        "outputId": "b3c2a2ac-6aaf-4af7-d392-edd871381983"
+      },
+      "execution_count": 24,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "50"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 24
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Edgecase: When two dates are available, taking the first date. Confirm how to handle.<br>\n",
+        "For eg.\n",
+        "\n",
+        "```nodes[568].metadata['issue_date']```\n",
+        "> January 1996 and July 2000 (two dates available)"
+      ],
+      "metadata": {
+        "id": "kcBvYnhmkm1w"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "date_list = []\n",
+        "\n",
+        "def convert_to_datetime64(docs):\n",
+        "  for doc in tqdm(tri_circulars_docs):\n",
+        "    doc_date = doc.metadata['issue_date']\n",
+        "    if not str(doc_date) == \"nan\":\n",
+        "      # pick first date if multiple available\n",
+        "      doc_date = \" \".join(doc_date.split()[0:2])\n",
+        "    doc.metadata['issue_date_ts'] = pd.to_datetime(doc_date, format=\"%B %Y\")\n",
+        "    date_list.append(doc.metadata['issue_date_ts'])\n",
+        "  return docs\n",
+        "\n",
+        "tri_circulars_docs = convert_to_datetime64(tri_circulars_docs)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 49,
+          "referenced_widgets": [
+            "1206539f66f1449d810d9cad2aabb6e7",
+            "0bc6385d4cfd44e0a3cedf095ba94947",
+            "618b0cf1761b4ade9c6db22db431a14d",
+            "1d2acbfaee294bf0ae117c237a5e4279",
+            "16359763e9f0423db14b17f7b9a62347",
+            "c2641a3eb6454554a0f0298ccf690e9a",
+            "1b5c6600c4b3492dbfe4abe6be520c8c",
+            "e4f48917db9b41518cbad1398f9d38c2",
+            "6ba4c39952ff45a895742560c8c6718d",
+            "47a64e0c956e4512ae347ae14c0d4213",
+            "b826e662dbcd4de8a8f89a9fa36cdfa3"
+          ]
+        },
+        "id": "_vF6MFuvkNzi",
+        "outputId": "91420c99-c851-4ff7-bd42-5910fa36a245"
+      },
+      "execution_count": 25,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "  0%|          | 0/50 [00:00<?, ?it/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "1206539f66f1449d810d9cad2aabb6e7"
+            }
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "tri_circulars_docs[0].metadata['issue_date']"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 36
+        },
+        "id": "TvGubziAkN_q",
+        "outputId": "37bd9ca2-e55b-40cc-f783-dca22136d768"
+      },
+      "execution_count": 26,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "'February 2024'"
+            ],
+            "application/vnd.google.colaboratory.intrinsic+json": {
+              "type": "string"
+            }
+          },
+          "metadata": {},
+          "execution_count": 26
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "tri_circulars_docs[0].metadata['issue_date_ts']"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "x92lnHnVltay",
+        "outputId": "08ad3b56-c918-4d11-ec1b-b3f9d7335078"
+      },
+      "execution_count": 27,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "Timestamp('2024-02-01 00:00:00')"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 27
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "pd.Series(date_list).value_counts()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 554
+        },
+        "id": "Yw3ik_JgfeLA",
+        "outputId": "38ecc959-714f-44f1-c955-6d8f292c2856"
+      },
+      "execution_count": 28,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "2024-02-01    20\n",
+              "2003-09-01     4\n",
+              "2000-07-01     4\n",
+              "2003-03-01     3\n",
+              "2009-05-01     3\n",
+              "2013-06-01     2\n",
+              "1996-01-01     2\n",
+              "2002-10-01     1\n",
+              "2001-02-01     1\n",
+              "2011-01-01     1\n",
+              "2002-12-01     1\n",
+              "2004-03-01     1\n",
+              "2024-03-01     1\n",
+              "2001-09-01     1\n",
+              "2016-07-01     1\n",
+              "Name: count, dtype: int64"
+            ],
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>count</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>2024-02-01</th>\n",
+              "      <td>20</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2003-09-01</th>\n",
+              "      <td>4</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2000-07-01</th>\n",
+              "      <td>4</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2003-03-01</th>\n",
+              "      <td>3</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2009-05-01</th>\n",
+              "      <td>3</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2013-06-01</th>\n",
+              "      <td>2</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1996-01-01</th>\n",
+              "      <td>2</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2002-10-01</th>\n",
+              "      <td>1</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2001-02-01</th>\n",
+              "      <td>1</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2011-01-01</th>\n",
+              "      <td>1</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2002-12-01</th>\n",
+              "      <td>1</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2004-03-01</th>\n",
+              "      <td>1</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2024-03-01</th>\n",
+              "      <td>1</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2001-09-01</th>\n",
+              "      <td>1</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2016-07-01</th>\n",
+              "      <td>1</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div><br><label><b>dtype:</b> int64</label>"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 28
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Chunking"
+      ],
+      "metadata": {
+        "id": "O5g7hyyoW7Jj"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "node_parser = MarkdownNodeParser()\n",
+        "nodes = node_parser.get_nodes_from_documents(tri_circulars_docs)\n",
+        "len(nodes)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "9f0IoBihW6-e",
+        "outputId": "e5cb63d5-4987-4677-c0a8-3e59f112fe69"
+      },
+      "execution_count": 29,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "725"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 29
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "chunk_word_counts = pd.Series([len(node.text.split()) for node in nodes])\n",
+        "chunk_word_counts.describe()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 335
+        },
+        "id": "DjrIS4V_YOgi",
+        "outputId": "cb823569-d362-4af3-a60b-781e2b813e5c"
+      },
+      "execution_count": 30,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "count    725.000000\n",
+              "mean      71.195862\n",
+              "std       77.791443\n",
+              "min        2.000000\n",
+              "25%       17.000000\n",
+              "50%       48.000000\n",
+              "75%       96.000000\n",
+              "max      833.000000\n",
+              "dtype: float64"
+            ],
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>0</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>count</th>\n",
+              "      <td>725.000000</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>mean</th>\n",
+              "      <td>71.195862</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>std</th>\n",
+              "      <td>77.791443</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>min</th>\n",
+              "      <td>2.000000</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>25%</th>\n",
+              "      <td>17.000000</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>50%</th>\n",
+              "      <td>48.000000</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>75%</th>\n",
+              "      <td>96.000000</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>max</th>\n",
+              "      <td>833.000000</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div><br><label><b>dtype:</b> float64</label>"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 30
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Embedding Model"
+      ],
+      "metadata": {
+        "id": "cMStjLBIZLlk"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def setup_embedding_model():\n",
+        "    \"\"\"\n",
+        "    Setup HuggingFace embedding model\n",
+        "    \"\"\"\n",
+        "    model_name = 'BAAI/bge-small-en-v1.5'\n",
+        "    return HuggingFaceEmbedding(\n",
+        "        model_name=model_name,\n",
+        "        trust_remote_code=True,\n",
+        "        cache_folder=\"/content/drive/MyDrive/Omdena/Regulatory RAG (SL Chapter)/code/model dev/cached_models/\"\n",
+        "        )\n",
+        "\n",
+        "embed_model = setup_embedding_model()"
+      ],
+      "metadata": {
+        "id": "wl75P6iLZKY1"
+      },
+      "execution_count": 31,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Groq + KDBAI API Setup"
+      ],
+      "metadata": {
+        "id": "qmKd2jtFYmOY"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from google.colab import userdata\n",
+        "GROQ_API_KEY = userdata.get('GROQ_API_KEY')"
+      ],
+      "metadata": {
+        "id": "hYXaJQD6Yq2H"
+      },
+      "execution_count": 32,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def setup_groq_llm():\n",
+        "    \"\"\"\n",
+        "    Setup Groq LLM\n",
+        "    \"\"\"\n",
+        "    groq_api_key = GROQ_API_KEY\n",
+        "    if not groq_api_key:\n",
+        "        raise ValueError(\"Please set GROQ_API_KEY environment variable\")\n",
+        "\n",
+        "    return Groq(\n",
+        "        api_key=groq_api_key,\n",
+        "        model=\"llama-3.1-8b-instant\",\n",
+        "        temperature=0.0\n",
+        "    )\n",
+        "\n",
+        "llm = setup_groq_llm()"
+      ],
+      "metadata": {
+        "id": "By3FsNuzZI-5"
+      },
+      "execution_count": 33,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# KDBAI API + Session Setup"
+      ],
+      "metadata": {
+        "id": "8jdCECWjaVKs"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "KDBAI_API_KEY = userdata.get('KDBAI_API_KEY')\n",
+        "KDBAI_SESSION_ENDPOINT = userdata.get('KDBAI_SESSION_ENDPOINT')"
+      ],
+      "metadata": {
+        "id": "EtP8cmlqaT_h"
+      },
+      "execution_count": 34,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def setup_kdbai_api():\n",
+        "  \"\"\"\n",
+        "  Setup KDBAI Session Endpoint and API\n",
+        "  \"\"\"\n",
+        "\n",
+        "  kdbai_endpoint = KDBAI_SESSION_ENDPOINT\n",
+        "  if not kdbai_endpoint:\n",
+        "        raise ValueError(\"Please set KDBAI_SESSION_ENDPOINT environment variable\")\n",
+        "\n",
+        "  kdbai_api_key = KDBAI_API_KEY\n",
+        "  if not kdbai_api_key:\n",
+        "        raise ValueError(\"Please set KDBAI_API_KEY environment variable\")\n",
+        "\n",
+        "  return kdbai.Session(\n",
+        "    endpoint=f\"https://cloud.kdb.ai/instance/{kdbai_endpoint}\",\n",
+        "    api_key=f\"{kdbai_api_key}\"\n",
+        "    )\n",
+        "\n",
+        "session = setup_kdbai_api()"
+      ],
+      "metadata": {
+        "id": "otPA0bsCa32P"
+      },
+      "execution_count": 35,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# KDBAI Vector Store Setup"
+      ],
+      "metadata": {
+        "id": "9nAb_08SZpi2"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Session Database"
+      ],
+      "metadata": {
+        "id": "NBTq4MmXeRHD"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "session.databases()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "9o0oMdg8bzUm",
+        "outputId": "eb54045a-e8ec-45f6-f6dc-810f3d563c9c"
+      },
+      "execution_count": 86,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[KDBAI database \"default\", KDBAI database \"srilanka_tri_circulars\"]"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 86
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# ensure no database called \"srilanka_tea\" exists\n",
+        "try:\n",
+        "    session.database(\"srilanka_tri_circulars\").drop()\n",
+        "except kdbai.KDBAIException:\n",
+        "    pass\n",
+        "\n",
+        "# Create the database\n",
+        "db = session.create_database(\"srilanka_tri_circulars\")\n",
+        "session.databases()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "XCbw0BOHcTcb",
+        "outputId": "9bab756a-655b-4ab4-951b-d21bc3d2bcf4"
+      },
+      "execution_count": 87,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[KDBAI database \"default\", KDBAI database \"srilanka_tri_circulars\"]"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 87
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Table Schema + Creation"
+      ],
+      "metadata": {
+        "id": "QZtApnqOeV-H"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# List all of the tables in the db\n",
+        "db.tables"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "MxUKNUhbd39j",
+        "outputId": "a7158056-c876-4ca3-bdd7-bcf25103e136"
+      },
+      "execution_count": 88,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[]"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 88
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Table - name & schema\n",
+        "table_name = \"rag_baseline\"\n",
+        "\n",
+        "table_schema = [\n",
+        "        dict(name=\"document_id\", type=\"bytes\"),\n",
+        "        dict(name=\"text\", type=\"bytes\"),\n",
+        "        dict(name=\"embeddings\", type=\"float32s\"),\n",
+        "        dict(name=\"issue_date_ts\", type=\"datetime64[ns]\"),\n",
+        "    ]\n",
+        "\n",
+        "indexFlat = {\n",
+        "        \"name\": \"flat_index\",\n",
+        "        \"type\": \"flat\",\n",
+        "        \"column\": \"embeddings\",\n",
+        "        \"params\": {'dims': 384, 'metric': 'CS'} # For similarity metric, choose from Euclidean Distance (L2), Dot Product (IP), or Cosine Similarity (CS).\n",
+        "    }"
+      ],
+      "metadata": {
+        "id": "iDk4CDxiePYG"
+      },
+      "execution_count": 89,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# First ensure the table does not already exist\n",
+        "try:\n",
+        "    db.table(\"rag_baseline\").drop()\n",
+        "except kdbai.KDBAIException:\n",
+        "    pass\n",
+        "\n",
+        "# Create table\n",
+        "table = db.create_table(table_name, table_schema, indexes=[indexFlat])\n",
+        "db.tables"
+      ],
+      "metadata": {
+        "id": "A9Bot7CjbzKs",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "17a5a475-1101-4ef0-ad39-057911c7ae0d"
+      },
+      "execution_count": 90,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[KDBAI table \"rag_baseline\"]"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 90
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "table.indexes"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "fFh9GKw_lGTQ",
+        "outputId": "2ddce9c3-c79a-49b0-9125-c30c9185896b"
+      },
+      "execution_count": 91,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[{'name': 'flat_index',\n",
+              "  'type': 'flat',\n",
+              "  'column': 'embeddings',\n",
+              "  'params': {'metric': 'CS', 'dims': 384}}]"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 91
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Insert Data into Tables"
+      ],
+      "metadata": {
+        "id": "LXRnsF_0mKPt"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from llama_index.vector_stores.kdbai import KDBAIVectorStore\n",
+        "from llama_index.core import StorageContext, Settings\n",
+        "from llama_index.core.indices import VectorStoreIndex"
+      ],
+      "metadata": {
+        "id": "tPvqbVTTmQZJ"
+      },
+      "execution_count": 92,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "Settings.llm = llm\n",
+        "Settings.embed_model = embed_model"
+      ],
+      "metadata": {
+        "id": "ll5UhUuUnSO4"
+      },
+      "execution_count": 93,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "%%time\n",
+        "\n",
+        "# Vector Store\n",
+        "vector_store = KDBAIVectorStore(\n",
+        "    table=table,\n",
+        "    index_name=\"circular_baseline_index\"\n",
+        "    )\n",
+        "\n",
+        "storage_context = StorageContext.from_defaults(vector_store=vector_store)\n",
+        "index = VectorStoreIndex.from_documents(\n",
+        "    tri_circulars_docs,\n",
+        "    storage_context=storage_context,\n",
+        "    transformations=[MarkdownNodeParser()]\n",
+        ")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "gGQRrQ4ImmH6",
+        "outputId": "61646377-d519-4b09-c115-3592c80ed174"
+      },
+      "execution_count": 94,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "CPU times: user 4min 43s, sys: 8.86 s, total: 4min 52s\n",
+            "Wall time: 4min 56s\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "table.query()"
+      ],
+      "metadata": {
+        "id": "nDS_pEn3Zov4",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 423
+        },
+        "outputId": "f05bcdaa-ee1f-457f-fa33-6a8d726741d6"
+      },
+      "execution_count": 95,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "                                 document_id  \\\n",
+              "0    b'246000ca-0ef6-4a5f-8d10-fc1f6a131e29'   \n",
+              "1    b'bb5a71bf-1eb5-4a79-8465-6315702da723'   \n",
+              "2    b'cd46e8a7-e016-4029-a670-86a30cc883ff'   \n",
+              "3    b'7bb0aa01-3dc6-4dcd-8e73-c11ed0da1153'   \n",
+              "4    b'3d9dca48-c5fd-4c06-9c76-ca231703105f'   \n",
+              "..                                       ...   \n",
+              "720  b'372ff8c2-6842-4f30-952d-da1d591098c2'   \n",
+              "721  b'b91b23fb-9703-4c84-8095-977e69c07ea9'   \n",
+              "722  b'a3f9c792-31a7-4742-a965-681b4fd6e957'   \n",
+              "723  b'6d9aefc1-b63a-4ee4-8eb2-21bf282e3804'   \n",
+              "724  b'81e6325e-be3a-4df8-8625-8d08b82af150'   \n",
+              "\n",
+              "                                                  text  \\\n",
+              "0                               b'# ADVISORY CIRCULAR'   \n",
+              "1    b'# No.DM JHL 925VynvT\\r\\n\\r\\nIssued in: Febru...   \n",
+              "2    b'# PROTECTION OF TEA FROM BLISTER BLIGHT\\r\\n\\...   \n",
+              "3    b'# 1. Introduction\\r\\n\\r\\nBlister blight dise...   \n",
+              "4    b'# 2. Disease Management\\r\\n\\r\\nIntegrated di...   \n",
+              "..                                                 ...   \n",
+              "720  b'# 3.4 Cultural Ecological Weed Control Metho...   \n",
+              "721  b'# 3.5 Manual Weeding\\r\\n\\r\\nManual weeding c...   \n",
+              "722  b'# 3.6 Mechanical Weeding\\r\\n\\r\\nSlash weedin...   \n",
+              "723  b'# 3.7 Chemical Weed Control\\r\\n\\r\\nChemical ...   \n",
+              "724  b'# 3.8 Biological Weed Control\\r\\n\\r\\nBiologi...   \n",
+              "\n",
+              "                                            embeddings issue_date_ts  \n",
+              "0    [-0.007562597, -0.026492892, 0.03072106, 0.018...    2024-02-01  \n",
+              "1    [-0.0121435, -0.023042029, 0.02277239, 0.01008...    2024-02-01  \n",
+              "2    [-0.009545566, -0.013665088, 0.028926225, 0.02...    2024-02-01  \n",
+              "3    [0.01621599, -0.022643894, 0.051311307, 0.0504...    2024-02-01  \n",
+              "4    [-0.011557567, -0.017213918, 0.047385782, 0.03...    2024-02-01  \n",
+              "..                                                 ...           ...  \n",
+              "720  [0.03683722, 0.023794655, 0.018897794, 0.05579...    2024-02-01  \n",
+              "721  [-0.008825304, -0.06506193, 0.017658412, 0.038...    2024-02-01  \n",
+              "722  [-0.0036664123, -0.043851368, 0.032723363, 0.0...    2024-02-01  \n",
+              "723  [0.021501746, -0.0641808, 0.016451132, 0.04455...    2024-02-01  \n",
+              "724  [0.05587266, -0.03632837, 0.0068967887, 0.0258...    2024-02-01  \n",
+              "\n",
+              "[725 rows x 4 columns]"
+            ],
+            "text/html": [
+              "\n",
+              "  <div id=\"df-dbefac1c-b112-4292-b904-32218688511f\" class=\"colab-df-container\">\n",
+              "    <div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>document_id</th>\n",
+              "      <th>text</th>\n",
+              "      <th>embeddings</th>\n",
+              "      <th>issue_date_ts</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>b'246000ca-0ef6-4a5f-8d10-fc1f6a131e29'</td>\n",
+              "      <td>b'# ADVISORY CIRCULAR'</td>\n",
+              "      <td>[-0.007562597, -0.026492892, 0.03072106, 0.018...</td>\n",
+              "      <td>2024-02-01</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>b'bb5a71bf-1eb5-4a79-8465-6315702da723'</td>\n",
+              "      <td>b'# No.DM JHL 925VynvT\\r\\n\\r\\nIssued in: Febru...</td>\n",
+              "      <td>[-0.0121435, -0.023042029, 0.02277239, 0.01008...</td>\n",
+              "      <td>2024-02-01</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>b'cd46e8a7-e016-4029-a670-86a30cc883ff'</td>\n",
+              "      <td>b'# PROTECTION OF TEA FROM BLISTER BLIGHT\\r\\n\\...</td>\n",
+              "      <td>[-0.009545566, -0.013665088, 0.028926225, 0.02...</td>\n",
+              "      <td>2024-02-01</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>b'7bb0aa01-3dc6-4dcd-8e73-c11ed0da1153'</td>\n",
+              "      <td>b'# 1. Introduction\\r\\n\\r\\nBlister blight dise...</td>\n",
+              "      <td>[0.01621599, -0.022643894, 0.051311307, 0.0504...</td>\n",
+              "      <td>2024-02-01</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>b'3d9dca48-c5fd-4c06-9c76-ca231703105f'</td>\n",
+              "      <td>b'# 2. Disease Management\\r\\n\\r\\nIntegrated di...</td>\n",
+              "      <td>[-0.011557567, -0.017213918, 0.047385782, 0.03...</td>\n",
+              "      <td>2024-02-01</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>...</th>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>720</th>\n",
+              "      <td>b'372ff8c2-6842-4f30-952d-da1d591098c2'</td>\n",
+              "      <td>b'# 3.4 Cultural Ecological Weed Control Metho...</td>\n",
+              "      <td>[0.03683722, 0.023794655, 0.018897794, 0.05579...</td>\n",
+              "      <td>2024-02-01</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>721</th>\n",
+              "      <td>b'b91b23fb-9703-4c84-8095-977e69c07ea9'</td>\n",
+              "      <td>b'# 3.5 Manual Weeding\\r\\n\\r\\nManual weeding c...</td>\n",
+              "      <td>[-0.008825304, -0.06506193, 0.017658412, 0.038...</td>\n",
+              "      <td>2024-02-01</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>722</th>\n",
+              "      <td>b'a3f9c792-31a7-4742-a965-681b4fd6e957'</td>\n",
+              "      <td>b'# 3.6 Mechanical Weeding\\r\\n\\r\\nSlash weedin...</td>\n",
+              "      <td>[-0.0036664123, -0.043851368, 0.032723363, 0.0...</td>\n",
+              "      <td>2024-02-01</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>723</th>\n",
+              "      <td>b'6d9aefc1-b63a-4ee4-8eb2-21bf282e3804'</td>\n",
+              "      <td>b'# 3.7 Chemical Weed Control\\r\\n\\r\\nChemical ...</td>\n",
+              "      <td>[0.021501746, -0.0641808, 0.016451132, 0.04455...</td>\n",
+              "      <td>2024-02-01</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>724</th>\n",
+              "      <td>b'81e6325e-be3a-4df8-8625-8d08b82af150'</td>\n",
+              "      <td>b'# 3.8 Biological Weed Control\\r\\n\\r\\nBiologi...</td>\n",
+              "      <td>[0.05587266, -0.03632837, 0.0068967887, 0.0258...</td>\n",
+              "      <td>2024-02-01</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "<p>725 rows × 4 columns</p>\n",
+              "</div>\n",
+              "    <div class=\"colab-df-buttons\">\n",
+              "\n",
+              "  <div class=\"colab-df-container\">\n",
+              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-dbefac1c-b112-4292-b904-32218688511f')\"\n",
+              "            title=\"Convert this dataframe to an interactive table.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
+              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
+              "  </svg>\n",
+              "    </button>\n",
+              "\n",
+              "  <style>\n",
+              "    .colab-df-container {\n",
+              "      display:flex;\n",
+              "      gap: 12px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert {\n",
+              "      background-color: #E8F0FE;\n",
+              "      border: none;\n",
+              "      border-radius: 50%;\n",
+              "      cursor: pointer;\n",
+              "      display: none;\n",
+              "      fill: #1967D2;\n",
+              "      height: 32px;\n",
+              "      padding: 0 0 0 0;\n",
+              "      width: 32px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert:hover {\n",
+              "      background-color: #E2EBFA;\n",
+              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "      fill: #174EA6;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-buttons div {\n",
+              "      margin-bottom: 4px;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert {\n",
+              "      background-color: #3B4455;\n",
+              "      fill: #D2E3FC;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert:hover {\n",
+              "      background-color: #434B5C;\n",
+              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+              "      fill: #FFFFFF;\n",
+              "    }\n",
+              "  </style>\n",
+              "\n",
+              "    <script>\n",
+              "      const buttonEl =\n",
+              "        document.querySelector('#df-dbefac1c-b112-4292-b904-32218688511f button.colab-df-convert');\n",
+              "      buttonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "\n",
+              "      async function convertToInteractive(key) {\n",
+              "        const element = document.querySelector('#df-dbefac1c-b112-4292-b904-32218688511f');\n",
+              "        const dataTable =\n",
+              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
+              "                                                    [key], {});\n",
+              "        if (!dataTable) return;\n",
+              "\n",
+              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
+              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
+              "          + ' to learn more about interactive tables.';\n",
+              "        element.innerHTML = '';\n",
+              "        dataTable['output_type'] = 'display_data';\n",
+              "        await google.colab.output.renderOutput(dataTable, element);\n",
+              "        const docLink = document.createElement('div');\n",
+              "        docLink.innerHTML = docLinkHtml;\n",
+              "        element.appendChild(docLink);\n",
+              "      }\n",
+              "    </script>\n",
+              "  </div>\n",
+              "\n",
+              "\n",
+              "<div id=\"df-91697f09-9b2b-41ee-8d20-6bc8d886e43d\">\n",
+              "  <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-91697f09-9b2b-41ee-8d20-6bc8d886e43d')\"\n",
+              "            title=\"Suggest charts\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+              "     width=\"24px\">\n",
+              "    <g>\n",
+              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
+              "    </g>\n",
+              "</svg>\n",
+              "  </button>\n",
+              "\n",
+              "<style>\n",
+              "  .colab-df-quickchart {\n",
+              "      --bg-color: #E8F0FE;\n",
+              "      --fill-color: #1967D2;\n",
+              "      --hover-bg-color: #E2EBFA;\n",
+              "      --hover-fill-color: #174EA6;\n",
+              "      --disabled-fill-color: #AAA;\n",
+              "      --disabled-bg-color: #DDD;\n",
+              "  }\n",
+              "\n",
+              "  [theme=dark] .colab-df-quickchart {\n",
+              "      --bg-color: #3B4455;\n",
+              "      --fill-color: #D2E3FC;\n",
+              "      --hover-bg-color: #434B5C;\n",
+              "      --hover-fill-color: #FFFFFF;\n",
+              "      --disabled-bg-color: #3B4455;\n",
+              "      --disabled-fill-color: #666;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart {\n",
+              "    background-color: var(--bg-color);\n",
+              "    border: none;\n",
+              "    border-radius: 50%;\n",
+              "    cursor: pointer;\n",
+              "    display: none;\n",
+              "    fill: var(--fill-color);\n",
+              "    height: 32px;\n",
+              "    padding: 0;\n",
+              "    width: 32px;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart:hover {\n",
+              "    background-color: var(--hover-bg-color);\n",
+              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "    fill: var(--button-hover-fill-color);\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart-complete:disabled,\n",
+              "  .colab-df-quickchart-complete:disabled:hover {\n",
+              "    background-color: var(--disabled-bg-color);\n",
+              "    fill: var(--disabled-fill-color);\n",
+              "    box-shadow: none;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-spinner {\n",
+              "    border: 2px solid var(--fill-color);\n",
+              "    border-color: transparent;\n",
+              "    border-bottom-color: var(--fill-color);\n",
+              "    animation:\n",
+              "      spin 1s steps(1) infinite;\n",
+              "  }\n",
+              "\n",
+              "  @keyframes spin {\n",
+              "    0% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "      border-left-color: var(--fill-color);\n",
+              "    }\n",
+              "    20% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    30% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    40% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    60% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    80% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "    90% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "  }\n",
+              "</style>\n",
+              "\n",
+              "  <script>\n",
+              "    async function quickchart(key) {\n",
+              "      const quickchartButtonEl =\n",
+              "        document.querySelector('#' + key + ' button');\n",
+              "      quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
+              "      quickchartButtonEl.classList.add('colab-df-spinner');\n",
+              "      try {\n",
+              "        const charts = await google.colab.kernel.invokeFunction(\n",
+              "            'suggestCharts', [key], {});\n",
+              "      } catch (error) {\n",
+              "        console.error('Error during call to suggestCharts:', error);\n",
+              "      }\n",
+              "      quickchartButtonEl.classList.remove('colab-df-spinner');\n",
+              "      quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
+              "    }\n",
+              "    (() => {\n",
+              "      let quickchartButtonEl =\n",
+              "        document.querySelector('#df-91697f09-9b2b-41ee-8d20-6bc8d886e43d button');\n",
+              "      quickchartButtonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "    })();\n",
+              "  </script>\n",
+              "</div>\n",
+              "\n",
+              "    </div>\n",
+              "  </div>\n"
+            ],
+            "application/vnd.google.colaboratory.intrinsic+json": {
+              "type": "dataframe",
+              "summary": "{\n  \"name\": \"table\",\n  \"rows\": 725,\n  \"fields\": [\n    {\n      \"column\": \"document_id\",\n      \"properties\": {\n        \"dtype\": \"string\",\n        \"num_unique_values\": 725,\n        \"samples\": [\n          \"b'cecb7291-74ba-4f42-a04f-f5513c3bd6ab'\",\n          \"b'8a0bdef0-9e62-467f-84b2-5d11dfc93b3f'\",\n          \"b'e8e9068b-eeb7-4151-b621-3be76c82fed1'\"\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"text\",\n      \"properties\": {\n        \"dtype\": \"string\",\n        \"num_unique_values\": 712,\n        \"samples\": [\n          \"b'# 1.1\\\\r\\\\n\\\\r\\\\nPlanting of shade trees has all along been associated with tea cultivation: Shade trees simulate forest conditions, which are believed to be the natural habitat of tea.'\",\n          \"b'# Figure 2\\\\r\\\\n\\\\r\\\\nA suitable single node cutting'\",\n          \"b'# 3. Other considerations\\\\r\\\\n\\\\r\\\\nShade trees should not be lopped during dry weather to prevent fire hazards. However, all grass clearings must be lopped prior to a drought.\\\\r\\\\n\\\\r\\\\nThe Tea Research Institute of Sri Lanka\\\\r\\\\n\\\\r\\\\nTalawakelle\\\\r\\\\n\\\\r\\\\n\\\\r\\\\nAll rights reserved. No part of this publication may be reproduced or transmitted in any form or by any means, electronic or mechanical, including photocopying, recording or information storage and retrieval, without permission in writing from the Director, Tea Research Institute of Sri Lanka.'\"\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"embeddings\",\n      \"properties\": {\n        \"dtype\": \"object\",\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"issue_date_ts\",\n      \"properties\": {\n        \"dtype\": \"date\",\n        \"min\": \"1996-01-01 00:00:00\",\n        \"max\": \"2024-03-01 00:00:00\",\n        \"num_unique_values\": 15,\n        \"samples\": [\n          \"2024-03-01 00:00:00\",\n          \"1996-01-01 00:00:00\",\n          \"2024-02-01 00:00:00\"\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    }\n  ]\n}"
+            }
+          },
+          "metadata": {},
+          "execution_count": 95
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Setting up Query Engine"
+      ],
+      "metadata": {
+        "id": "qK3sRaOAhapF"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "%%time\n",
+        "\n",
+        "# Using llama-3.1-8b-instant, the 128k tokens context size can take 100 pages.\n",
+        "K = 15\n",
+        "\n",
+        "# query_engine = index.as_query_engine(llm=llm)\n",
+        "\n",
+        "query_engine = index.as_query_engine(\n",
+        "    similarity_top_k=K,\n",
+        "    llm=llm,\n",
+        "    vector_store_kwargs={\n",
+        "        \"index\": \"flat_index\"#,\n",
+        "        # \"filter\": [[\"<\", \"publication_date\", pd.to_datetime(\"\")]],\n",
+        "        # \"sort_columns\": \"publication_date\",\n",
+        "    },\n",
+        ")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "pOKayT5VhZ5e",
+        "outputId": "e641174f-67ac-4bfd-a860-929b97593ffd"
+      },
+      "execution_count": 96,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "CPU times: user 463 µs, sys: 0 ns, total: 463 µs\n",
+            "Wall time: 472 µs\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Querying Vector Store with Questions"
+      ],
+      "metadata": {
+        "id": "GiIr17wJgu-Z"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "%%time\n",
+        "\n",
+        "input_query = \"Were there any major circulars for special export duties changes?\"\n",
+        "\n",
+        "result = query_engine.query(input_query)\n",
+        "print(result.response)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 405
+        },
+        "id": "UlxXU6WMOG_V",
+        "outputId": "c24f29f8-f639-4e91-ff67-e8cf630e7415"
+      },
+      "execution_count": 97,
+      "outputs": [
+        {
+          "output_type": "error",
+          "ename": "TypeError",
+          "evalue": "Client.__init__() got an unexpected keyword argument 'proxies'",
+          "traceback": [
+            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+            "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+            "\u001b[0;32m<timed exec>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/llama_index/core/instrumentation/dispatcher.py\u001b[0m in \u001b[0;36mwrapper\u001b[0;34m(func, instance, args, kwargs)\u001b[0m\n\u001b[1;32m    319\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    320\u001b[0m             \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 321\u001b[0;31m                 \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    322\u001b[0m                 \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresult\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0masyncio\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mFuture\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    323\u001b[0m                     \u001b[0;31m# If the result is a Future, wrap it\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/llama_index/core/base/base_query_engine.py\u001b[0m in \u001b[0;36mquery\u001b[0;34m(self, str_or_query_bundle)\u001b[0m\n\u001b[1;32m     50\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mstr_or_query_bundle\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstr\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     51\u001b[0m                 \u001b[0mstr_or_query_bundle\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mQueryBundle\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mstr_or_query_bundle\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 52\u001b[0;31m             \u001b[0mquery_result\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_query\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mstr_or_query_bundle\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     53\u001b[0m         dispatcher.event(\n\u001b[1;32m     54\u001b[0m             \u001b[0mQueryEndEvent\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mquery\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mstr_or_query_bundle\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mresponse\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mquery_result\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/llama_index/core/instrumentation/dispatcher.py\u001b[0m in \u001b[0;36mwrapper\u001b[0;34m(func, instance, args, kwargs)\u001b[0m\n\u001b[1;32m    319\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    320\u001b[0m             \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 321\u001b[0;31m                 \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    322\u001b[0m                 \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresult\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0masyncio\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mFuture\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    323\u001b[0m                     \u001b[0;31m# If the result is a Future, wrap it\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/llama_index/core/query_engine/retriever_query_engine.py\u001b[0m in \u001b[0;36m_query\u001b[0;34m(self, query_bundle)\u001b[0m\n\u001b[1;32m    177\u001b[0m         ) as query_event:\n\u001b[1;32m    178\u001b[0m             \u001b[0mnodes\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mretrieve\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mquery_bundle\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 179\u001b[0;31m             response = self._response_synthesizer.synthesize(\n\u001b[0m\u001b[1;32m    180\u001b[0m                 \u001b[0mquery\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mquery_bundle\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    181\u001b[0m                 \u001b[0mnodes\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mnodes\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/llama_index/core/instrumentation/dispatcher.py\u001b[0m in \u001b[0;36mwrapper\u001b[0;34m(func, instance, args, kwargs)\u001b[0m\n\u001b[1;32m    319\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    320\u001b[0m             \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 321\u001b[0;31m                 \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    322\u001b[0m                 \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresult\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0masyncio\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mFuture\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    323\u001b[0m                     \u001b[0;31m# If the result is a Future, wrap it\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/llama_index/core/response_synthesizers/base.py\u001b[0m in \u001b[0;36msynthesize\u001b[0;34m(self, query, nodes, additional_source_nodes, **response_kwargs)\u001b[0m\n\u001b[1;32m    239\u001b[0m             \u001b[0mpayload\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m{\u001b[0m\u001b[0mEventPayload\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mQUERY_STR\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mquery\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mquery_str\u001b[0m\u001b[0;34m}\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    240\u001b[0m         ) as event:\n\u001b[0;32m--> 241\u001b[0;31m             response_str = self.get_response(\n\u001b[0m\u001b[1;32m    242\u001b[0m                 \u001b[0mquery_str\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mquery\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mquery_str\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    243\u001b[0m                 text_chunks=[\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/llama_index/core/instrumentation/dispatcher.py\u001b[0m in \u001b[0;36mwrapper\u001b[0;34m(func, instance, args, kwargs)\u001b[0m\n\u001b[1;32m    319\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    320\u001b[0m             \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 321\u001b[0;31m                 \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    322\u001b[0m                 \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresult\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0masyncio\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mFuture\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    323\u001b[0m                     \u001b[0;31m# If the result is a Future, wrap it\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/llama_index/core/response_synthesizers/compact_and_refine.py\u001b[0m in \u001b[0;36mget_response\u001b[0;34m(self, query_str, text_chunks, prev_response, **response_kwargs)\u001b[0m\n\u001b[1;32m     41\u001b[0m         \u001b[0;31m# the refine template does not account for size of previous answer.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     42\u001b[0m         \u001b[0mnew_texts\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_make_compact_text_chunks\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mquery_str\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtext_chunks\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 43\u001b[0;31m         return super().get_response(\n\u001b[0m\u001b[1;32m     44\u001b[0m             \u001b[0mquery_str\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mquery_str\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     45\u001b[0m             \u001b[0mtext_chunks\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mnew_texts\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/llama_index/core/instrumentation/dispatcher.py\u001b[0m in \u001b[0;36mwrapper\u001b[0;34m(func, instance, args, kwargs)\u001b[0m\n\u001b[1;32m    319\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    320\u001b[0m             \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 321\u001b[0;31m                 \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    322\u001b[0m                 \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresult\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0masyncio\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mFuture\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    323\u001b[0m                     \u001b[0;31m# If the result is a Future, wrap it\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/llama_index/core/response_synthesizers/refine.py\u001b[0m in \u001b[0;36mget_response\u001b[0;34m(self, query_str, text_chunks, prev_response, **response_kwargs)\u001b[0m\n\u001b[1;32m    177\u001b[0m                 \u001b[0;31m# if this is the first chunk, and text chunk already\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    178\u001b[0m                 \u001b[0;31m# is an answer, then return it\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 179\u001b[0;31m                 response = self._give_response_single(\n\u001b[0m\u001b[1;32m    180\u001b[0m                     \u001b[0mquery_str\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtext_chunk\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mresponse_kwargs\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    181\u001b[0m                 )\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/llama_index/core/response_synthesizers/refine.py\u001b[0m in \u001b[0;36m_give_response_single\u001b[0;34m(self, query_str, text_chunk, **response_kwargs)\u001b[0m\n\u001b[1;32m    239\u001b[0m                     structured_response = cast(\n\u001b[1;32m    240\u001b[0m                         \u001b[0mStructuredRefineResponse\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 241\u001b[0;31m                         program(\n\u001b[0m\u001b[1;32m    242\u001b[0m                             \u001b[0mcontext_str\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcur_text_chunk\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    243\u001b[0m                             \u001b[0;34m**\u001b[0m\u001b[0mresponse_kwargs\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/llama_index/core/instrumentation/dispatcher.py\u001b[0m in \u001b[0;36mwrapper\u001b[0;34m(func, instance, args, kwargs)\u001b[0m\n\u001b[1;32m    319\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    320\u001b[0m             \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 321\u001b[0;31m                 \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    322\u001b[0m                 \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresult\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0masyncio\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mFuture\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    323\u001b[0m                     \u001b[0;31m# If the result is a Future, wrap it\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/llama_index/core/response_synthesizers/refine.py\u001b[0m in \u001b[0;36m__call__\u001b[0;34m(self, *args, **kwds)\u001b[0m\n\u001b[1;32m     83\u001b[0m                 \u001b[0manswer\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0manswer\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmodel_dump_json\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     84\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 85\u001b[0;31m             answer = self._llm.predict(\n\u001b[0m\u001b[1;32m     86\u001b[0m                 \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_prompt\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     87\u001b[0m                 \u001b[0;34m**\u001b[0m\u001b[0mkwds\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/llama_index/core/instrumentation/dispatcher.py\u001b[0m in \u001b[0;36mwrapper\u001b[0;34m(func, instance, args, kwargs)\u001b[0m\n\u001b[1;32m    319\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    320\u001b[0m             \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 321\u001b[0;31m                 \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    322\u001b[0m                 \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresult\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0masyncio\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mFuture\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    323\u001b[0m                     \u001b[0;31m# If the result is a Future, wrap it\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/llama_index/core/llms/llm.py\u001b[0m in \u001b[0;36mpredict\u001b[0;34m(self, prompt, **prompt_args)\u001b[0m\n\u001b[1;32m    594\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmetadata\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mis_chat_model\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    595\u001b[0m             \u001b[0mmessages\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_get_messages\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mprompt\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mprompt_args\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 596\u001b[0;31m             \u001b[0mchat_response\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mchat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmessages\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    597\u001b[0m             \u001b[0moutput\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mchat_response\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmessage\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcontent\u001b[0m \u001b[0;32mor\u001b[0m \u001b[0;34m\"\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    598\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/llama_index/core/instrumentation/dispatcher.py\u001b[0m in \u001b[0;36mwrapper\u001b[0;34m(func, instance, args, kwargs)\u001b[0m\n\u001b[1;32m    319\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    320\u001b[0m             \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 321\u001b[0;31m                 \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    322\u001b[0m                 \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresult\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0masyncio\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mFuture\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    323\u001b[0m                     \u001b[0;31m# If the result is a Future, wrap it\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/llama_index/llms/openai_like/base.py\u001b[0m in \u001b[0;36mchat\u001b[0;34m(self, messages, **kwargs)\u001b[0m\n\u001b[1;32m    115\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0mcompletion_response_to_chat_response\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcompletion_response\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    116\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 117\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0msuper\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mchat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmessages\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    118\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    119\u001b[0m     def stream_chat(\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/llama_index/core/instrumentation/dispatcher.py\u001b[0m in \u001b[0;36mwrapper\u001b[0;34m(func, instance, args, kwargs)\u001b[0m\n\u001b[1;32m    319\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    320\u001b[0m             \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 321\u001b[0;31m                 \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    322\u001b[0m                 \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresult\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0masyncio\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mFuture\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    323\u001b[0m                     \u001b[0;31m# If the result is a Future, wrap it\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/llama_index/core/llms/callbacks.py\u001b[0m in \u001b[0;36mwrapped_llm_chat\u001b[0;34m(_self, messages, **kwargs)\u001b[0m\n\u001b[1;32m    171\u001b[0m                 )\n\u001b[1;32m    172\u001b[0m                 \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 173\u001b[0;31m                     \u001b[0mf_return_val\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0m_self\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmessages\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    174\u001b[0m                 \u001b[0;32mexcept\u001b[0m \u001b[0mBaseException\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    175\u001b[0m                     callback_manager.on_event_end(\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/llama_index/llms/openai/base.py\u001b[0m in \u001b[0;36mchat\u001b[0;34m(self, messages, **kwargs)\u001b[0m\n\u001b[1;32m    353\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    354\u001b[0m             \u001b[0mchat_fn\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcompletion_to_chat_decorator\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_complete\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 355\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mchat_fn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmessages\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    356\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    357\u001b[0m     \u001b[0;34m@\u001b[0m\u001b[0mllm_chat_callback\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/llama_index/llms/openai/base.py\u001b[0m in \u001b[0;36mwrapper\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m    104\u001b[0m             \u001b[0mmax_seconds\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m20\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    105\u001b[0m         )\n\u001b[0;32m--> 106\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mretry\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mf\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    107\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    108\u001b[0m     \u001b[0;32mreturn\u001b[0m \u001b[0mwrapper\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/tenacity/__init__.py\u001b[0m in \u001b[0;36mwrapped_f\u001b[0;34m(*args, **kw)\u001b[0m\n\u001b[1;32m    334\u001b[0m             \u001b[0mcopy\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcopy\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    335\u001b[0m             \u001b[0mwrapped_f\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstatistics\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcopy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstatistics\u001b[0m  \u001b[0;31m# type: ignore[attr-defined]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 336\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mcopy\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkw\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    337\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    338\u001b[0m         \u001b[0;32mdef\u001b[0m \u001b[0mretry_with\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mt\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mAny\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mt\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mAny\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m->\u001b[0m \u001b[0mWrappedFn\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/tenacity/__init__.py\u001b[0m in \u001b[0;36m__call__\u001b[0;34m(self, fn, *args, **kwargs)\u001b[0m\n\u001b[1;32m    473\u001b[0m         \u001b[0mretry_state\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mRetryCallState\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mretry_object\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfn\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfn\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0margs\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkwargs\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    474\u001b[0m         \u001b[0;32mwhile\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 475\u001b[0;31m             \u001b[0mdo\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0miter\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mretry_state\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mretry_state\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    476\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdo\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mDoAttempt\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    477\u001b[0m                 \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/tenacity/__init__.py\u001b[0m in \u001b[0;36miter\u001b[0;34m(self, retry_state)\u001b[0m\n\u001b[1;32m    374\u001b[0m         \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    375\u001b[0m         \u001b[0;32mfor\u001b[0m \u001b[0maction\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0miter_state\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mactions\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 376\u001b[0;31m             \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0maction\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mretry_state\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    377\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    378\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/tenacity/__init__.py\u001b[0m in \u001b[0;36m<lambda>\u001b[0;34m(rs)\u001b[0m\n\u001b[1;32m    396\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_post_retry_check_actions\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mretry_state\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;34m\"RetryCallState\"\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m->\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    397\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0miter_state\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mis_explicit_retry\u001b[0m \u001b[0;32mor\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0miter_state\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mretry_run_result\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 398\u001b[0;31m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_add_action_func\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;32mlambda\u001b[0m \u001b[0mrs\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mrs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutcome\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mresult\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    399\u001b[0m             \u001b[0;32mreturn\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    400\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/lib/python3.10/concurrent/futures/_base.py\u001b[0m in \u001b[0;36mresult\u001b[0;34m(self, timeout)\u001b[0m\n\u001b[1;32m    449\u001b[0m                     \u001b[0;32mraise\u001b[0m \u001b[0mCancelledError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    450\u001b[0m                 \u001b[0;32melif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_state\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0mFINISHED\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 451\u001b[0;31m                     \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__get_result\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    452\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    453\u001b[0m                 \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_condition\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwait\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtimeout\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/lib/python3.10/concurrent/futures/_base.py\u001b[0m in \u001b[0;36m__get_result\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    401\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_exception\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    402\u001b[0m             \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 403\u001b[0;31m                 \u001b[0;32mraise\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_exception\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    404\u001b[0m             \u001b[0;32mfinally\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    405\u001b[0m                 \u001b[0;31m# Break a reference cycle with the exception in self._exception\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/tenacity/__init__.py\u001b[0m in \u001b[0;36m__call__\u001b[0;34m(self, fn, *args, **kwargs)\u001b[0m\n\u001b[1;32m    476\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdo\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mDoAttempt\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    477\u001b[0m                 \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 478\u001b[0;31m                     \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    479\u001b[0m                 \u001b[0;32mexcept\u001b[0m \u001b[0mBaseException\u001b[0m\u001b[0;34m:\u001b[0m  \u001b[0;31m# noqa: B902\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    480\u001b[0m                     \u001b[0mretry_state\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mset_exception\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msys\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mexc_info\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m  \u001b[0;31m# type: ignore[arg-type]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/llama_index/llms/openai/base.py\u001b[0m in \u001b[0;36m_chat\u001b[0;34m(self, messages, **kwargs)\u001b[0m\n\u001b[1;32m    423\u001b[0m     \u001b[0;34m@\u001b[0m\u001b[0mllm_retry_decorator\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    424\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_chat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmessages\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mSequence\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mChatMessage\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mAny\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m->\u001b[0m \u001b[0mChatResponse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 425\u001b[0;31m         \u001b[0mclient\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_get_client\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    426\u001b[0m         \u001b[0mmessage_dicts\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mto_openai_message_dicts\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmessages\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmodel\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmodel\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    427\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/llama_index/llms/openai/base.py\u001b[0m in \u001b[0;36m_get_client\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    295\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    296\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_client\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 297\u001b[0;31m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_client\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mSyncOpenAI\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m**\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_get_credential_kwargs\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    298\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_client\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    299\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/openai/_client.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, api_key, organization, project, base_url, timeout, max_retries, default_headers, default_query, http_client, _strict_response_validation)\u001b[0m\n\u001b[1;32m    121\u001b[0m             \u001b[0mbase_url\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34mf\"https://api.openai.com/v1\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    122\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 123\u001b[0;31m         super().__init__(\n\u001b[0m\u001b[1;32m    124\u001b[0m             \u001b[0mversion\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0m__version__\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    125\u001b[0m             \u001b[0mbase_url\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mbase_url\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/openai/_base_client.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, version, base_url, max_retries, timeout, transport, proxies, limits, http_client, custom_headers, custom_query, _strict_response_validation)\u001b[0m\n\u001b[1;32m    855\u001b[0m             \u001b[0m_strict_response_validation\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0m_strict_response_validation\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    856\u001b[0m         )\n\u001b[0;32m--> 857\u001b[0;31m         self._client = http_client or SyncHttpxClientWrapper(\n\u001b[0m\u001b[1;32m    858\u001b[0m             \u001b[0mbase_url\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mbase_url\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    859\u001b[0m             \u001b[0;31m# cast to a valid type because mypy doesn't understand our type narrowing\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.10/dist-packages/openai/_base_client.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, **kwargs)\u001b[0m\n\u001b[1;32m    753\u001b[0m         \u001b[0mkwargs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msetdefault\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"limits\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mDEFAULT_CONNECTION_LIMITS\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    754\u001b[0m         \u001b[0mkwargs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msetdefault\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"follow_redirects\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 755\u001b[0;31m         \u001b[0msuper\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__init__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    756\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    757\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;31mTypeError\u001b[0m: Client.__init__() got an unexpected keyword argument 'proxies'"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "kVNalAo1OHXt"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "HFwr_nqaOG13"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# table.drop()"
+      ],
+      "metadata": {
+        "id": "7j34fG-PM_wR"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
Added notebook for a basic RAG implementation (for TRI Circulars only) with llama-index and KDBAI vector store using HuggingFace embeddings and GROQ LLM API. Notebook Location: `task-4-model-building/experimental_notebooks/`

**TODO:** 
Towards the end, the KDBAI vector store `query_engine.query` is not throwing error: 
`TypeError: Client.__init__() got an unexpected keyword argument 'proxies'`
Requires debugging and needs to be fixed.
